### PR TITLE
Organize core and optional test suites

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,12 @@ testpaths = [
     "tests/unittest",
 ]
 pythonpath = "."
+markers = [
+    "optional: tests that require optional dependency extras",
+    "jax: tests that require the jax extra",
+    "symbolic: tests that require the symbolic extra",
+    "visualization: tests that require the visualization extra",
+]
 
 [tool.hatch.version]
 source = "vcs"

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,48 @@
+ # Test suite organization
+
+The default pytest discovery lives in `tests/unittest`.
+
+## Core behavior without optional extras
+
+Run tests that should pass with only the required project dependencies and the
+`dev` extra installed:
+
+```bash
+pytest -m "not optional"
+```
+
+This excludes tests that need optional extras such as JAX, SymPy, meshcat, or
+pygame.
+
+## Default local run
+
+```bash
+pytest
+```
+
+Optional tests remain collected, but skip at runtime when their dependency is
+not installed.
+
+## Full functionality run
+
+Install all extras, then run either the optional subset or the whole suite:
+
+```bash
+pip install -e ".[dev,symbolic,jax,visualization]"
+SDL_VIDEODRIVER=dummy pytest -m optional
+SDL_VIDEODRIVER=dummy pytest
+```
+
+`SDL_VIDEODRIVER=dummy` lets pygame smoke tests initialize in headless CI or
+Cursor Cloud sessions.
+
+## Marker policy
+
+- `optional`: any test that needs a dependency outside the base package
+- `jax`: tests requiring `jax` / `jaxlib`
+- `symbolic`: tests requiring `sympy`
+- `visualization`: tests requiring `meshcat` or `pygame`
+
+When adding optional behavior, put the import inside a guarded block and add the
+appropriate marker(s). This keeps `pytest -m "not optional"` a dependable
+behavior suite for minimal installations.

--- a/tests/unittest/conftest.py
+++ b/tests/unittest/conftest.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import pytest
+
+OPTIONAL_MARKERS = ("jax", "symbolic", "visualization")
+
+
+def pytest_collection_modifyitems(items):
+    """Mark every optional-extra test with the aggregate ``optional`` marker."""
+    optional = pytest.mark.optional
+    for item in items:
+        if any(item.get_closest_marker(name) for name in OPTIONAL_MARKERS):
+            item.add_marker(optional)

--- a/tests/unittest/test_blocks.py
+++ b/tests/unittest/test_blocks.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy as np
 
+from minilink.blocks.basic import Integrator, PropController
 from minilink.blocks.sources import Source, Step
 
 
@@ -20,6 +21,28 @@ class TestBlocks(unittest.TestCase):
         y_after = step.h(x=[], u=[], t=3.0)
         np.testing.assert_array_equal(y_before, np.array([0.0]))
         np.testing.assert_array_equal(y_after, np.array([1.0]))
+
+    def test_integrator_dynamics_and_output(self):
+        plant = Integrator()
+        plant.params["k"] = 2.0
+
+        np.testing.assert_array_equal(
+            plant.f(np.array([3.0]), np.array([4.0])),
+            np.array([8.0]),
+        )
+        np.testing.assert_array_equal(
+            plant.h(np.array([3.0]), np.array([4.0])),
+            np.array([3.0]),
+        )
+
+    def test_prop_controller_scales_tracking_error(self):
+        controller = PropController()
+        controller.params["Kp"] = 2.5
+
+        np.testing.assert_array_equal(
+            controller.ctl(np.array([]), np.array([3.0, 1.0])),
+            np.array([5.0]),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unittest/test_compile_pipeline.py
+++ b/tests/unittest/test_compile_pipeline.py
@@ -11,9 +11,9 @@ Validates that:
 import unittest
 
 import numpy as np
+import pytest
 
 from minilink.blocks.basic import Integrator, PropController
-from minilink.jax_utils import array_module
 from minilink.compile.compiler import (
     build_execution_plan,
     check_algebraic_loops,
@@ -23,7 +23,7 @@ from minilink.compile.execution_plan import ExecutionPlan
 from minilink.compile.numpy_evaluator import NumpyDiagramEvaluator
 from minilink.core.diagram import DiagramSystem
 from minilink.core.framework import DynamicSystem, StaticSystem, System
-
+from minilink.jax_utils import array_module
 
 # ── Helper: reusable test diagrams ───────────────────────────────────
 
@@ -241,23 +241,18 @@ class TestNumpyDiagramEvaluator(unittest.TestCase):
         self.diag = _build_small_closed_loop()
         self.evaluator = compile_diagram(self.diag)
 
-    def test_f_matches_diagram_f(self):
-        x = np.array([0.3])
-        u = np.array([1.2])
-        t = 0.1
-
-        dx_reference = self.diag.f(x, u, t)
-        dx_compiled = self.evaluator.f(x, u, t)
-
-        np.testing.assert_allclose(dx_compiled, dx_reference, atol=1e-10)
-
-    def test_f_multiple_points(self):
-        """Test at several state/input combinations."""
-        for x_val, u_val in [(0.0, 0.0), (1.0, 2.0), (-5.0, 10.0)]:
+    def test_f_matches_diagram_f_for_representative_points(self):
+        """Compiled f matches the recursive reference over several operating points."""
+        for x_val, u_val, t in [
+            (0.3, 1.2, 0.1),
+            (0.0, 0.0, 0.0),
+            (1.0, 2.0, 0.0),
+            (-5.0, 10.0, 0.0),
+        ]:
             x = np.array([x_val])
             u = np.array([u_val])
-            dx_ref = self.diag.f(x, u, 0.0)
-            dx_comp = self.evaluator.f(x, u, 0.0)
+            dx_ref = self.diag.f(x, u, t)
+            dx_comp = self.evaluator.f(x, u, t)
             np.testing.assert_allclose(dx_comp, dx_ref, atol=1e-10)
 
     def test_compute_internal_signals_non_empty(self):
@@ -381,7 +376,6 @@ class TestNumpyDiagramEvaluator(unittest.TestCase):
 
     def test_as_scipy_rhs(self):
         x = np.array([0.4])
-        u = np.array([1.0])
         t = 0.15
         rhs = self.evaluator.as_scipy_rhs()
         np.testing.assert_allclose(
@@ -408,38 +402,48 @@ except ImportError:
     _JAX_AVAILABLE = False
 
 
+@pytest.mark.optional
+@pytest.mark.jax
 @unittest.skipUnless(_JAX_AVAILABLE, "JAX not installed")
 class TestJaxDiagramEvaluatorOutputs(unittest.TestCase):
     """JaxDiagramEvaluator boundary outputs are JIT-compiled and match NumPy."""
 
-    def test_outputs_matches_numpy_no_boundary_ports(self):
+    def test_outputs_match_numpy_for_boundary_configurations(self):
+        for diag in [
+            _build_small_closed_loop_jax(),
+            _build_closed_loop_with_external_output_jax(),
+        ]:
+            ev_np = compile_diagram(diag, backend="numpy")
+            ev_jax = compile_diagram(diag, backend="jax")
+            self.assertIsInstance(ev_jax, JaxDiagramEvaluator)
+
+            x_np, u_np = np.array([0.5]), np.array([1.0])
+            x_j = jnp.array([0.5], dtype=jnp.float32)
+            u_j = jnp.array([1.0], dtype=jnp.float32)
+            t = 0.0
+
+            d_np = ev_np.outputs(x_np, u_np, t)
+            d_jx = ev_jax.outputs(x_j, u_j, t)
+            self.assertEqual(set(d_np.keys()), set(d_jx.keys()))
+            for k in d_np:
+                np.testing.assert_allclose(np.asarray(d_jx[k]), d_np[k], atol=1e-5)
+
+    def test_f_and_get_f_jit_match_numpy(self):
         diag = _build_small_closed_loop_jax()
         ev_np = compile_diagram(diag, backend="numpy")
         ev_jax = compile_diagram(diag, backend="jax")
-        self.assertIsInstance(ev_jax, JaxDiagramEvaluator)
+        x_np, u_np = np.array([0.3]), np.array([1.2])
+        x_j = jnp.array(x_np, dtype=jnp.float32)
+        u_j = jnp.array(u_np, dtype=jnp.float32)
+        t = 0.1
 
-        x_np, u_np = np.array([0.5]), np.array([1.0])
-        x_j = jnp.array([0.5], dtype=jnp.float32)
-        u_j = jnp.array([1.0], dtype=jnp.float32)
-        t = 0.0
-
-        d_np = ev_np.outputs(x_np, u_np, t)
-        d_jx = ev_jax.outputs(x_j, u_j, t)
-        self.assertEqual(d_np, {})
-        self.assertEqual(d_jx, {})
-
-    def test_outputs_matches_numpy_with_external_port(self):
-        diag = _build_closed_loop_with_external_output_jax()
-        ev_np = compile_diagram(diag, backend="numpy")
-        ev_jax = compile_diagram(diag, backend="jax")
-        x_j = jnp.array([0.5], dtype=jnp.float32)
-        u_j = jnp.array([1.0], dtype=jnp.float32)
-        t = 0.0
-        d_np = ev_np.outputs(np.array([0.5]), np.array([1.0]), t)
-        d_jx = ev_jax.outputs(x_j, u_j, t)
-        self.assertEqual(set(d_np.keys()), set(d_jx.keys()))
-        for k in d_np:
-            np.testing.assert_allclose(np.asarray(d_jx[k]), d_np[k], atol=1e-5)
+        dx_np = ev_np.f(x_np, u_np, t)
+        np.testing.assert_allclose(np.asarray(ev_jax.f(x_j, u_j, t)), dx_np, atol=1e-5)
+        np.testing.assert_allclose(
+            np.asarray(ev_jax.get_f_jit()(x_j, u_j, t)),
+            dx_np,
+            atol=1e-5,
+        )
 
     def test_get_outputs_jit_matches_outputs(self):
         diag = _build_closed_loop_with_external_output_jax()

--- a/tests/unittest/test_graphviz.py
+++ b/tests/unittest/test_graphviz.py
@@ -1,0 +1,52 @@
+import unittest
+
+from minilink.blocks.basic import Integrator, PropController
+from minilink.core.diagram import DiagramSystem
+from minilink.graphical.graphe import (
+    get_diagram_graphe,
+    get_system_block_html,
+    get_system_graphe,
+    plot_graphviz,
+)
+
+
+class TestGraphviz(unittest.TestCase):
+    def test_system_block_html_includes_named_ports(self):
+        html = get_system_block_html(PropController(), "ctl")
+
+        self.assertIn("Controller::ctl", html)
+        self.assertIn('PORT="ref"', html)
+        self.assertIn('PORT="u"', html)
+
+    def test_system_graphe_contains_block_label(self):
+        graph = get_system_graphe(Integrator())
+
+        self.assertIsNotNone(graph)
+        self.assertIn("Integrator", graph.source)
+        self.assertIn('PORT="y"', graph.source)
+
+    def test_diagram_graphe_contains_subsystems_and_connections(self):
+        diagram = DiagramSystem()
+        diagram.graphe_building_verbose = False
+        diagram.add_subsystem(PropController(), "ctl")
+        diagram.add_subsystem(Integrator(), "plant")
+        diagram.add_input_port(1, "ref")
+        diagram.connect("input", "ref", "ctl", "ref")
+        diagram.connect("plant", "y", "ctl", "y")
+        diagram.connect("ctl", "u", "plant", "u")
+        diagram.connect_new_output_port("plant", "y", "y_meas")
+
+        graph = get_diagram_graphe(diagram)
+
+        self.assertIsNotNone(graph)
+        self.assertIn("ctl", graph.source)
+        self.assertIn("plant", graph.source)
+        self.assertIn("input:ref:e -> ctl:ref:w", graph.source)
+        self.assertIn("output:y_meas:w", graph.source)
+
+    def test_plot_graphviz_accepts_none_graph(self):
+        self.assertIsNone(plot_graphviz(None, show_inline=False, show_pdf=False))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittest/test_mechanical_jax.py
+++ b/tests/unittest/test_mechanical_jax.py
@@ -3,6 +3,7 @@
 import unittest
 
 import numpy as np
+import pytest
 
 try:
     import jax
@@ -15,6 +16,8 @@ except ImportError:
     HAS_JAX = False
 
 
+@pytest.mark.optional
+@pytest.mark.jax
 @unittest.skipUnless(HAS_JAX, "jax not installed")
 class TestMechanicalSystemJax(unittest.TestCase):
     def test_f_is_jaxpr_traceable(self):

--- a/tests/unittest/test_physics_engine_jax.py
+++ b/tests/unittest/test_physics_engine_jax.py
@@ -3,6 +3,7 @@
 import unittest
 
 import numpy as np
+import pytest
 
 try:
     import jax
@@ -23,6 +24,8 @@ except ImportError:
     HAS_JAX = False
 
 
+@pytest.mark.optional
+@pytest.mark.jax
 @unittest.skipUnless(HAS_JAX, "jax not installed")
 class TestPhysicsEngineJax(unittest.TestCase):
     def _single_world(self):

--- a/tests/unittest/test_physics_system_minilink.py
+++ b/tests/unittest/test_physics_system_minilink.py
@@ -3,20 +3,23 @@
 import unittest
 
 import numpy as np
+import pytest
 
 from minilink.core.diagram import DiagramSystem
 
 try:
     import jax.numpy as jnp
 
-    from minilink.physics.system import PhysicsWorldSystem
     from minilink.physics.engine_jax import PlaneModel, SphereModel, make_world_model
+    from minilink.physics.system import PhysicsWorldSystem
 
     HAS_JAX = True
 except ImportError:
     HAS_JAX = False
 
 
+@pytest.mark.optional
+@pytest.mark.jax
 @unittest.skipUnless(HAS_JAX, "jax not installed")
 class TestPhysicsSystemMinilink(unittest.TestCase):
     def _make_sys(self):

--- a/tests/unittest/test_simulation_speed_benchmarks.py
+++ b/tests/unittest/test_simulation_speed_benchmarks.py
@@ -5,10 +5,11 @@ import io
 import unittest
 
 import numpy as np
+import pytest
 
 from minilink.benchmark.simulation_speed import (
-    TRUTH_SOLVER,
     TRUTH_BACKEND,
+    TRUTH_SOLVER,
     benchmark_sim_backend,
     benchmark_sim_speed_matrix,
     format_benchmark_backend_label,
@@ -40,6 +41,8 @@ class TestSimulationSpeedBenchmark(unittest.TestCase):
     def test_format_benchmark_backend_label_numpy_unchanged(self):
         self.assertEqual(format_benchmark_backend_label("numpy"), "numpy")
 
+    @pytest.mark.optional
+    @pytest.mark.jax
     def test_format_benchmark_backend_label_jax_shape(self):
         label = format_benchmark_backend_label("jax")
         try:

--- a/tests/unittest/test_simulator.py
+++ b/tests/unittest/test_simulator.py
@@ -3,9 +3,10 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import numpy as np
+import pytest
 
-from minilink.jax_utils import array_module
 from minilink.core.framework import DynamicSystem
+from minilink.jax_utils import array_module
 from minilink.simulation.simulator import COMPILE_BACKEND_AUTO, Simulator
 
 
@@ -78,6 +79,8 @@ class TestNewSimulator(unittest.TestCase):
         sim = Simulator(StableLinearSystem(), tf=1.0, n_steps=5, verbose=False)
         self.assertEqual(sim.compile_backend, "numpy")
 
+    @pytest.mark.optional
+    @pytest.mark.jax
     @unittest.skipUnless(_have_jax(), "jax not installed")
     def test_compile_backend_auto_resolves_to_jax_when_available(self):
         sim = Simulator(
@@ -89,6 +92,8 @@ class TestNewSimulator(unittest.TestCase):
         )
         self.assertEqual(sim.compile_backend, "jax")
 
+    @pytest.mark.optional
+    @pytest.mark.jax
     @unittest.skipUnless(_have_jax(), "jax not installed")
     def test_auto_selects_rk4_for_large_uniform_grid_with_jax(self):
         sim = Simulator(
@@ -100,6 +105,8 @@ class TestNewSimulator(unittest.TestCase):
         )
         self.assertEqual(sim.solver_mode, "rk4_fixedsteps")
 
+    @pytest.mark.optional
+    @pytest.mark.jax
     @unittest.skipUnless(_have_jax(), "jax not installed")
     def test_jax_grid_below_threshold_stays_scipy(self):
         sim = Simulator(
@@ -111,6 +118,8 @@ class TestNewSimulator(unittest.TestCase):
         )
         self.assertEqual(sim.solver_mode, "scipy")
 
+    @pytest.mark.optional
+    @pytest.mark.jax
     @unittest.skipUnless(_have_jax(), "jax not installed")
     def test_discontinuous_jax_large_grid_stays_stiff(self):
         sim = Simulator(

--- a/tests/unittest/test_symbolic.py
+++ b/tests/unittest/test_symbolic.py
@@ -3,14 +3,15 @@
 import unittest
 
 import numpy as np
+import pytest
 
 try:
     import sympy as sp
     from sympy.physics.mechanics import dynamicsymbols
 
     from minilink.mechanics.symbolic.derivation import derive_lagrange
-    from minilink.mechanics.symbolic.model import MechanicalModel
     from minilink.mechanics.symbolic.export import create_minilink_system
+    from minilink.mechanics.symbolic.model import MechanicalModel
     from minilink.mechanics.symbolic.symbolic_system import MechanicalSystem
 
     HAS_SYMPY = True
@@ -25,6 +26,8 @@ except ImportError:
     HAS_JAX = False
 
 
+@pytest.mark.optional
+@pytest.mark.symbolic
 @unittest.skipUnless(HAS_SYMPY, "sympy not installed")
 class TestSymbolicMechanics(unittest.TestCase):
     def test_single_link_pendulum_derive_and_export(self):
@@ -107,6 +110,7 @@ class TestSymbolicMechanics(unittest.TestCase):
         T = num.get_kinematic_transforms(np.zeros(2), np.zeros(1), 0.0)
         self.assertEqual(len(prim), len(T))
 
+    @pytest.mark.jax
     @unittest.skipUnless(HAS_SYMPY and HAS_JAX, "sympy and jax required")
     def test_to_minilink_jax_returns_jax_mechanical_system(self):
         from minilink.mechanics.mechanical import JaxMechanicalSystem

--- a/tests/unittest/test_visualization_optional.py
+++ b/tests/unittest/test_visualization_optional.py
@@ -1,0 +1,92 @@
+import unittest
+
+import numpy as np
+import pytest
+
+from minilink.graphical.primitives import Point
+from minilink.graphical.renderers.meshcat_renderer import MeshcatCanvas, _import_meshcat
+from minilink.graphical.renderers.pygame_renderer import PygameCanvas, _import_pygame
+
+
+def _has_meshcat():
+    try:
+        _import_meshcat()
+    except ImportError:
+        return False
+    return True
+
+
+def _has_pygame():
+    try:
+        _import_pygame()
+    except ImportError:
+        return False
+    return True
+
+
+@pytest.mark.optional
+@pytest.mark.visualization
+class TestVisualizationOptionalImports(unittest.TestCase):
+    def test_import_meshcat_reports_extra_when_missing(self):
+        try:
+            meshcat = _import_meshcat()
+        except ImportError as exc:
+            self.assertIn("minilink[visualization]", str(exc))
+        else:
+            self.assertTrue(hasattr(meshcat, "Visualizer"))
+
+    def test_import_pygame_reports_extra_when_missing(self):
+        try:
+            pygame = _import_pygame()
+        except ImportError as exc:
+            self.assertIn("minilink[visualization]", str(exc))
+        else:
+            self.assertTrue(hasattr(pygame, "init"))
+
+
+@pytest.mark.optional
+@pytest.mark.visualization
+class TestMeshcatOptionalSmoke(unittest.TestCase):
+    @pytest.mark.skipif(not _has_meshcat(), reason="meshcat not installed")
+    def test_canvas_can_create_point_geometry_without_opening_browser(self):
+        meshcat = _import_meshcat()
+        vis = meshcat.Visualizer()
+        canvas = MeshcatCanvas(vis, is_3d=True)
+
+        canvas.ensure_objects([Point([0.0, 0.0, 0.0])])
+        canvas.update_primitive(0, Point([0.0, 0.0, 0.0]), np.eye(4))
+
+        self.assertEqual(canvas._n_slots, 1)
+        canvas.clear()
+
+
+@pytest.mark.optional
+@pytest.mark.visualization
+class TestPygameOptionalSmoke(unittest.TestCase):
+    @pytest.mark.skipif(not _has_pygame(), reason="pygame not installed")
+    def test_canvas_maps_world_coordinates_to_screen(self):
+        pygame = _import_pygame()
+        pygame.init()
+        try:
+            surface = pygame.Surface((100, 100))
+            animator = type("AnimatorStub", (), {"domain": ((-1.0, 1.0), (-1.0, 1.0))})()
+            canvas = PygameCanvas(surface, animator, is_3d=False)
+            self.assertEqual(canvas._to_screen(0.0, 0.0), (50, 50))
+        finally:
+            pygame.quit()
+
+    @pytest.mark.skipif(not _has_pygame(), reason="pygame not installed")
+    def test_canvas_draws_point_to_surface(self):
+        pygame = _import_pygame()
+        pygame.init()
+        try:
+            surface = pygame.Surface((100, 100))
+            animator = type("AnimatorStub", (), {"domain": ((-1.0, 1.0), (-1.0, 1.0))})()
+            canvas = PygameCanvas(surface, animator, is_3d=False)
+            canvas.draw_primitive(Point([0.0, 0.0, 0.0]), np.eye(4), pygame)
+        finally:
+            pygame.quit()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add pytest markers and a collection hook so core behavior can run with `pytest -m "not optional"` while optional suites are grouped by `jax`, `symbolic`, and `visualization` markers.
- Document core/default/full test commands in `tests/README.md`.
- Add missing Graphviz and optional visualization smoke coverage, extend basic block behavior tests, and mark the existing JAX/SymPy optional tests.
- Merge duplicated compile-pipeline assertions while preserving the dev-alex JAX-friendly fixtures.

## Testing
- `SDL_VIDEODRIVER=dummy .venv/bin/python -m pytest -m 'not optional'`
- `SDL_VIDEODRIVER=dummy .venv/bin/python -m pytest -m optional`
- `SDL_VIDEODRIVER=dummy .venv/bin/python -m pytest`
- `rm -rf .venv-core && python3 -m venv .venv-core && .venv-core/bin/python -m pip install -e '.[dev]' && SDL_VIDEODRIVER=dummy .venv-core/bin/python -m pytest -m 'not optional' && SDL_VIDEODRIVER=dummy .venv-core/bin/python -m pytest`
- `.venv/bin/python -m ruff check pyproject.toml tests/README.md tests/unittest/conftest.py tests/unittest/test_blocks.py tests/unittest/test_compile_pipeline.py tests/unittest/test_graphviz.py tests/unittest/test_mechanical_jax.py tests/unittest/test_physics_engine_jax.py tests/unittest/test_physics_system_minilink.py tests/unittest/test_simulation_speed_benchmarks.py tests/unittest/test_simulator.py tests/unittest/test_symbolic.py tests/unittest/test_visualization_optional.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-045e8f6b-62eb-49de-887e-f096cb158149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-045e8f6b-62eb-49de-887e-f096cb158149"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

