### PR TITLE
Add Ipopt optimizer backend and optimizer benchmark module

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -78,10 +78,12 @@ minilink/<package>/
 ```text
 minilink/optimization/
   mathematical_program.py
+  benchmark.py
   optimizers/
     __init__.py
     optimizer.py
     scipy_minimize.py
+    ipopt.py
 
 minilink/planning/
   initial_guess.py
@@ -232,10 +234,12 @@ minilink/
 ├── optimization/
 │   ├── __init__.py
 │   ├── mathematical_program.py
+│   ├── benchmark.py
 │   └── optimizers/
 │       ├── __init__.py
 │       ├── optimizer.py
-│       └── scipy_minimize.py
+│       ├── scipy_minimize.py
+│       └── ipopt.py
 │
 ├── analysis/
 │   └── __init__.py
@@ -530,6 +534,7 @@ Optional helpers for benchmark and regression-style comparisons. They are **not*
 | `minilink.compile.benchmark` | `benchmark_f_evaluators` returns rows for native `system.f`, compiled NumPy, and compiled JAX evaluators over a fixed `(x, u, t)` sample; `print_f_benchmark` formats the result. Native timing is skipped on `RecursionError` so deep recursive diagrams can still benchmark compiled paths. |
 | `minilink.simulation.benchmark` | `benchmark_simulation_backend(system, candidate=...)` compares one `SimulationBenchmarkVariant` to `TRUTH_SIMULATION_VARIANT`; `benchmark_simulation_matrix(system, variants=...)` sweeps explicit variants such as `DEFAULT_SIMULATION_VARIANTS`; `print_simulation_matrix_benchmark` formats rows and highlights the fastest accurate variant. |
 | `minilink.planning.trajectory_optimization.benchmark` | `benchmark_trajectory_optimization` compares transcription, compile backend, derivative mode, precision, cold/warm start, optimizer backend, optimizer method, and optimizer options; `print_trajectory_optimization_benchmark` formats the result. |
+| `minilink.optimization.benchmark` | `benchmark_optimizer_backends` sweeps a list of `OptimizerBenchmarkVariant` (SciPy ``minimize`` and Ipopt via ``cyipopt``) over a small set of textbook nonlinear-program test cases (`STANDARD_OPTIMIZATION_CASES`: unconstrained quadratic, Rosenbrock, box-constrained QP, equality circle, inequality QP) and reports solve time, iteration counts, cost / decision error, and constraint feasibility; `print_optimizer_benchmark` formats the result. |
 
 Programmatic imports should use the defining modules, e.g. `from minilink.simulation.benchmark import benchmark_simulation_matrix, DEFAULT_SIMULATION_VARIANTS` or `from minilink.compile.benchmark import benchmark_f_evaluators`. Runnable examples are flat scripts under `tests/benchmark/` (see `agent.md` for manual script style). Optional helper ``tests/benchmark/tune_scipy_vs_rk4.py`` runs ten ``solve_ivp`` search rounds against an RK4+JAX wall-time bar.
 

--- a/minilink/optimization/benchmark.py
+++ b/minilink/optimization/benchmark.py
@@ -1,0 +1,508 @@
+"""Benchmarks for finite-dimensional :class:`MathematicalProgram` solvers.
+
+Sweep a list of optimizer backends (currently SciPy ``minimize`` and Ipopt via
+``cyipopt``) over a set of textbook nonlinear-program test cases and compare
+solve time, iteration counts, final cost, and constraint feasibility. Mirrors
+the layout of :mod:`minilink.simulation.benchmark` and
+:mod:`minilink.compile.benchmark`.
+
+Usage::
+
+    from minilink.optimization.benchmark import (
+        benchmark_optimizer_backends,
+        default_optimizer_variants,
+        print_optimizer_benchmark,
+        STANDARD_OPTIMIZATION_CASES,
+    )
+
+    variants = default_optimizer_variants()
+    result = benchmark_optimizer_backends(STANDARD_OPTIMIZATION_CASES, variants)
+    print_optimizer_benchmark(result)
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from minilink.optimization.mathematical_program import (
+    EqualityConstraint,
+    InequalityConstraint,
+    MathematicalProgram,
+    OptimizationResult,
+    VariableBounds,
+)
+from minilink.optimization.optimizers.optimizer import Optimizer
+from minilink.optimization.optimizers.scipy_minimize import ScipyMinimizeOptimizer
+
+
+# --- Variant / Case / Result records ---------------------------------------
+
+
+@dataclass(frozen=True)
+class OptimizerBenchmarkVariant:
+    """One optimizer backend configuration to benchmark.
+
+    Parameters
+    ----------
+    name : str
+        Short label used in the benchmark table.
+    backend : str
+        Backend identifier, ``"scipy"`` or ``"ipopt"``.
+    method : str
+        Backend-specific method (e.g. SciPy ``"SLSQP"``, ``"trust-constr"``).
+        Ignored by Ipopt (which uses interior-point).
+    options : Mapping
+        Backend-specific options dictionary.
+    """
+
+    name: str
+    backend: str
+    method: str = ""
+    options: Mapping[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class OptimizerBenchmarkCase:
+    """One named mathematical-program test problem.
+
+    Parameters
+    ----------
+    id : str
+        Short machine-readable id.
+    label : str
+        Human-readable label for tables.
+    build : callable
+        Returns a fresh :class:`MathematicalProgram` (built per run so internal
+        state is never shared between solvers).
+    z_star : np.ndarray, optional
+        Known optimum used to report a relative ``z`` error. ``None`` skips it.
+    cost_star : float, optional
+        Known optimal cost. ``None`` skips the cost-error column.
+    """
+
+    id: str
+    label: str
+    build: Callable[[], MathematicalProgram]
+    z_star: np.ndarray | None = None
+    cost_star: float | None = None
+
+
+@dataclass(frozen=True)
+class OptimizerBenchmarkRow:
+    """One measured (case, variant) combination."""
+
+    case_id: str
+    case_label: str
+    variant: OptimizerBenchmarkVariant
+    success: bool
+    solve_s: float
+    cost: float | None
+    cost_err: float | None
+    z_err: float | None
+    eq_inf: float
+    min_ineq: float | None
+    bound_inf: float
+    nit: int | None
+    nfev: int | None
+    njev: int | None
+    message: str
+
+
+@dataclass(frozen=True)
+class OptimizerBenchmarkResult:
+    """All rows for a sweep of cases and optimizer variants."""
+
+    cases: tuple[OptimizerBenchmarkCase, ...]
+    variants: tuple[OptimizerBenchmarkVariant, ...]
+    n_runs: int
+    rows: tuple[OptimizerBenchmarkRow, ...]
+
+
+# --- Standard variants and cases -------------------------------------------
+
+
+def default_optimizer_variants(
+    *,
+    maxiter: int = 200,
+    ftol: float = 1e-8,
+    tol: float = 1e-8,
+) -> tuple[OptimizerBenchmarkVariant, ...]:
+    """Default SciPy and (when available) Ipopt benchmark sweep."""
+    variants: list[OptimizerBenchmarkVariant] = [
+        OptimizerBenchmarkVariant(
+            name="scipy-SLSQP",
+            backend="scipy",
+            method="SLSQP",
+            options={"maxiter": int(maxiter), "ftol": float(ftol), "disp": False},
+        ),
+        OptimizerBenchmarkVariant(
+            name="scipy-trust-constr",
+            backend="scipy",
+            method="trust-constr",
+            options={"maxiter": int(maxiter), "xtol": float(ftol), "disp": False},
+        ),
+    ]
+    if ipopt_optimizer_available():
+        variants.append(
+            OptimizerBenchmarkVariant(
+                name="ipopt",
+                backend="ipopt",
+                method="ipopt",
+                options={"max_iter": int(maxiter), "tol": float(tol), "print_level": 0},
+            )
+        )
+    return tuple(variants)
+
+
+def ipopt_optimizer_available() -> bool:
+    """Return ``True`` when ``cyipopt`` can be imported."""
+    try:
+        import cyipopt  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+# --- Standard test problems (textbook NLPs) --------------------------------
+#
+# Small, well-known nonlinear programs for solver comparison. The problems are
+# defined explicitly with gradients so SciPy and Ipopt receive identical
+# information.
+
+
+def _quadratic_problem() -> MathematicalProgram:
+    # min 0.5 (z - c)^T (z - c)  with c = [1, 2, 3]; z* = c, cost* = 0
+    c = np.array([1.0, 2.0, 3.0])
+
+    def J(z: np.ndarray) -> float:
+        return 0.5 * float(np.sum((z - c) ** 2))
+
+    def grad(z: np.ndarray) -> np.ndarray:
+        return z - c
+
+    return MathematicalProgram(J=J, grad=grad, z0=np.zeros(3))
+
+
+def _rosenbrock_problem(n: int = 5) -> MathematicalProgram:
+    # Classic Rosenbrock; z* = ones(n), cost* = 0
+    def J(z: np.ndarray) -> float:
+        return float(np.sum(100.0 * (z[1:] - z[:-1] ** 2) ** 2 + (1.0 - z[:-1]) ** 2))
+
+    def grad(z: np.ndarray) -> np.ndarray:
+        g = np.zeros_like(z)
+        g[:-1] = -400.0 * z[:-1] * (z[1:] - z[:-1] ** 2) - 2.0 * (1.0 - z[:-1])
+        g[1:] += 200.0 * (z[1:] - z[:-1] ** 2)
+        return g
+
+    z0 = -1.2 * np.ones(n)
+    z0[1::2] = 1.0
+    return MathematicalProgram(J=J, grad=grad, z0=z0)
+
+
+def _box_constrained_quadratic_problem() -> MathematicalProgram:
+    # min 0.5 z^T z subject to z >= 1; z* = ones, cost* = 0.5 * n
+    n = 4
+
+    def J(z: np.ndarray) -> float:
+        return 0.5 * float(np.sum(z**2))
+
+    def grad(z: np.ndarray) -> np.ndarray:
+        return z
+
+    bounds = VariableBounds(lower=np.ones(n), upper=np.full(n, np.inf))
+    return MathematicalProgram(J=J, grad=grad, z0=2.0 * np.ones(n), bounds=bounds)
+
+
+def _equality_circle_problem() -> MathematicalProgram:
+    # min z[0] + z[1]  s.t.  z[0]^2 + z[1]^2 = 1
+    # KKT optimum at z* = (-1, -1) / sqrt(2), cost* = -sqrt(2)
+    def J(z: np.ndarray) -> float:
+        return float(z[0] + z[1])
+
+    def grad(z: np.ndarray) -> np.ndarray:
+        return np.array([1.0, 1.0])
+
+    def h(z: np.ndarray) -> np.ndarray:
+        return np.array([z[0] ** 2 + z[1] ** 2 - 1.0])
+
+    def jac_h(z: np.ndarray) -> np.ndarray:
+        return np.array([[2.0 * z[0], 2.0 * z[1]]])
+
+    eq = EqualityConstraint(h=h, jac=jac_h, name="unit_circle")
+    return MathematicalProgram(
+        J=J,
+        grad=grad,
+        z0=np.array([-0.5, -0.5]),
+        equalities=(eq,),
+    )
+
+
+def _inequality_quadratic_problem() -> MathematicalProgram:
+    # min (z[0] - 2)^2 + (z[1] - 1)^2  s.t.  z[0] + z[1] <= 1, z >= 0
+    # i.e. g1(z) = 1 - z[0] - z[1] >= 0, g2(z) = z >= 0 (as box bounds)
+    def J(z: np.ndarray) -> float:
+        return float((z[0] - 2.0) ** 2 + (z[1] - 1.0) ** 2)
+
+    def grad(z: np.ndarray) -> np.ndarray:
+        return np.array([2.0 * (z[0] - 2.0), 2.0 * (z[1] - 1.0)])
+
+    def g(z: np.ndarray) -> np.ndarray:
+        return np.array([1.0 - z[0] - z[1]])
+
+    def jac_g(z: np.ndarray) -> np.ndarray:
+        return np.array([[-1.0, -1.0]])
+
+    ineq = InequalityConstraint(g=g, jac=jac_g, name="sum_le_one")
+    bounds = VariableBounds(lower=np.zeros(2), upper=np.full(2, np.inf))
+    return MathematicalProgram(
+        J=J,
+        grad=grad,
+        z0=np.array([0.5, 0.5]),
+        bounds=bounds,
+        inequalities=(ineq,),
+    )
+
+
+STANDARD_OPTIMIZATION_CASES: tuple[OptimizerBenchmarkCase, ...] = (
+    OptimizerBenchmarkCase(
+        id="quadratic",
+        label="Unconstrained quadratic",
+        build=_quadratic_problem,
+        z_star=np.array([1.0, 2.0, 3.0]),
+        cost_star=0.0,
+    ),
+    OptimizerBenchmarkCase(
+        id="rosenbrock",
+        label="Rosenbrock (n=5)",
+        build=lambda: _rosenbrock_problem(5),
+        z_star=np.ones(5),
+        cost_star=0.0,
+    ),
+    OptimizerBenchmarkCase(
+        id="box_qp",
+        label="Box-constrained QP",
+        build=_box_constrained_quadratic_problem,
+        z_star=np.ones(4),
+        cost_star=0.5 * 4,
+    ),
+    OptimizerBenchmarkCase(
+        id="circle_eq",
+        label="Equality circle",
+        build=_equality_circle_problem,
+        z_star=np.array([-1.0, -1.0]) / np.sqrt(2.0),
+        cost_star=-np.sqrt(2.0),
+    ),
+    OptimizerBenchmarkCase(
+        id="ineq_qp",
+        label="Inequality QP",
+        build=_inequality_quadratic_problem,
+        # KKT solution: project (2, 1) onto z[0] + z[1] = 1 with z >= 0
+        z_star=np.array([1.0, 0.0]),
+        cost_star=(1.0 - 2.0) ** 2 + (0.0 - 1.0) ** 2,
+    ),
+)
+
+
+# --- Sweep ------------------------------------------------------------------
+
+
+def benchmark_optimizer_backends(
+    cases: Sequence[OptimizerBenchmarkCase] = STANDARD_OPTIMIZATION_CASES,
+    variants: Sequence[OptimizerBenchmarkVariant] | None = None,
+    *,
+    n_runs: int = 1,
+) -> OptimizerBenchmarkResult:
+    """Run each variant on each case and return a flat row table.
+
+    The mathematical program is rebuilt for every (case, variant, run) so
+    optimizers do not see warmed-up internal state.
+    """
+    variant_tuple = (
+        default_optimizer_variants() if variants is None else tuple(variants)
+    )
+    case_tuple = tuple(cases)
+
+    rows: list[OptimizerBenchmarkRow] = []
+    for case in case_tuple:
+        for variant in variant_tuple:
+            rows.append(_run_case(case, variant, n_runs=n_runs))
+    return OptimizerBenchmarkResult(
+        cases=case_tuple,
+        variants=variant_tuple,
+        n_runs=int(n_runs),
+        rows=tuple(rows),
+    )
+
+
+def _run_case(
+    case: OptimizerBenchmarkCase,
+    variant: OptimizerBenchmarkVariant,
+    *,
+    n_runs: int,
+) -> OptimizerBenchmarkRow:
+    optimizer = _make_optimizer(variant)
+
+    durations: list[float] = []
+    last_result: OptimizationResult | None = None
+    last_program: MathematicalProgram | None = None
+    for _ in range(int(n_runs)):
+        program = case.build()
+        last_program = program
+        t0 = time.perf_counter()
+        last_result = optimizer.solve(program)
+        durations.append(time.perf_counter() - t0)
+
+    assert last_result is not None and last_program is not None
+    eq_inf, min_ineq, bound_inf = _constraint_metrics(last_program, last_result.z)
+    return OptimizerBenchmarkRow(
+        case_id=case.id,
+        case_label=case.label,
+        variant=variant,
+        success=bool(last_result.success),
+        solve_s=float(np.mean(durations)),
+        cost=last_result.cost,
+        cost_err=_cost_error(last_result.cost, case.cost_star),
+        z_err=_z_error(last_result.z, case.z_star),
+        eq_inf=eq_inf,
+        min_ineq=min_ineq,
+        bound_inf=bound_inf,
+        nit=_stat_int(last_result, "nit"),
+        nfev=_stat_int(last_result, "nfev"),
+        njev=_stat_int(last_result, "njev"),
+        message=last_result.message,
+    )
+
+
+def _make_optimizer(variant: OptimizerBenchmarkVariant) -> Optimizer:
+    if variant.backend == "scipy":
+        method = variant.method or "SLSQP"
+        return ScipyMinimizeOptimizer(method=method, options=dict(variant.options))
+    if variant.backend == "ipopt":
+        from minilink.optimization.optimizers.ipopt import IpoptOptimizer
+
+        opts = dict(variant.options)
+        tol = opts.pop("tol", None)
+        return IpoptOptimizer(options=opts, tol=tol)
+    raise ValueError(f"Unknown optimizer backend {variant.backend!r}")
+
+
+# --- Metrics ---------------------------------------------------------------
+
+
+def _constraint_metrics(
+    program: MathematicalProgram,
+    z: np.ndarray,
+) -> tuple[float, float | None, float]:
+    eq_inf = 0.0
+    if program.equalities:
+        eq_inf = max(
+            float(np.max(np.abs(equality.residual(z))))
+            for equality in program.equalities
+        )
+
+    min_ineq: float | None = None
+    if program.inequalities:
+        min_ineq = min(
+            float(np.min(inequality.margin(z))) for inequality in program.inequalities
+        )
+
+    bound_inf = 0.0
+    if program.bounds is not None:
+        if program.bounds.lower is not None:
+            bound_inf = max(
+                bound_inf,
+                float(np.max(np.maximum(program.bounds.lower - z, 0.0))),
+            )
+        if program.bounds.upper is not None:
+            bound_inf = max(
+                bound_inf,
+                float(np.max(np.maximum(z - program.bounds.upper, 0.0))),
+            )
+    return eq_inf, min_ineq, bound_inf
+
+
+def _cost_error(cost: float | None, cost_star: float | None) -> float | None:
+    if cost is None or cost_star is None:
+        return None
+    denom = max(1.0, abs(float(cost_star)))
+    return float(abs(float(cost) - float(cost_star)) / denom)
+
+
+def _z_error(z: np.ndarray, z_star: np.ndarray | None) -> float | None:
+    if z_star is None:
+        return None
+    diff = np.linalg.norm(np.asarray(z, dtype=float) - np.asarray(z_star, dtype=float))
+    ref = np.linalg.norm(np.asarray(z_star, dtype=float))
+    if ref > 0.0:
+        return float(diff / ref)
+    return float(diff)
+
+
+def _stat_int(result: OptimizationResult, name: str) -> int | None:
+    value = result.stats.get(name)
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+# --- Table formatting ------------------------------------------------------
+
+_COL_CASE = 24
+_COL_VARIANT = 22
+
+
+def print_optimizer_benchmark(result: OptimizerBenchmarkResult) -> None:
+    """Print a compact (case, variant) table for an optimizer benchmark."""
+    width = _COL_CASE + _COL_VARIANT + 90
+    print()
+    print("-" * width)
+    print(
+        "  optimizer-backend benchmark   "
+        f"variants={len(result.variants)}  "
+        f"cases={len(result.cases)}  runs={result.n_runs}"
+    )
+    print("-" * width)
+    print(_header_line())
+    print("-" * width)
+    for row in result.rows:
+        print(_format_row(row))
+    print("-" * width)
+    failures = [row for row in result.rows if not row.success]
+    if failures:
+        print()
+        print("  failures:")
+        for row in failures:
+            print(f"    {row.case_id:<14} {row.variant.name:<18} : {row.message}")
+
+
+def _header_line() -> str:
+    return (
+        f"  {'case':<{_COL_CASE}} {'variant':<{_COL_VARIANT}} "
+        f"{'ok':>3} {'solve_s':>9} {'cost':>13} {'|dcost|':>10} "
+        f"{'|dz|/|z*|':>10} {'eq_inf':>10} {'bnd_inf':>9} "
+        f"{'nit':>5} {'nfev':>6} {'njev':>6}"
+    )
+
+
+def _format_row(row: OptimizerBenchmarkRow) -> str:
+    cost = "n/a" if row.cost is None else f"{row.cost:13.5g}"
+    cost_err = "n/a" if row.cost_err is None else f"{row.cost_err:10.2e}"
+    z_err = "n/a" if row.z_err is None else f"{row.z_err:10.2e}"
+    nit = "n/a" if row.nit is None else f"{row.nit:5d}"
+    nfev = "n/a" if row.nfev is None else f"{row.nfev:6d}"
+    njev = "n/a" if row.njev is None else f"{row.njev:6d}"
+    return (
+        f"  {row.case_label:<{_COL_CASE}} {row.variant.name:<{_COL_VARIANT}} "
+        f"{('Y' if row.success else 'N'):>3} {row.solve_s:9.5f} {cost} "
+        f"{cost_err} {z_err} "
+        f"{row.eq_inf:10.2e} {row.bound_inf:9.2e} "
+        f"{nit} {nfev} {njev}"
+    )

--- a/minilink/optimization/optimizers/ipopt.py
+++ b/minilink/optimization/optimizers/ipopt.py
@@ -1,0 +1,126 @@
+"""Cyipopt :func:`cyipopt.minimize_ipopt` optimizer.
+
+Wraps the COIN-OR Ipopt interior-point solver behind the same generic
+:class:`~minilink.optimization.optimizers.optimizer.Optimizer` contract used by
+:class:`~minilink.optimization.optimizers.scipy_minimize.ScipyMinimizeOptimizer`,
+so a :class:`~minilink.optimization.mathematical_program.MathematicalProgram`
+can switch between the SciPy and Ipopt backends with no other code changes.
+
+Equality constraints ``h(z) = 0`` and inequality constraints ``g(z) >= 0`` are
+forwarded as ``type='eq'`` and ``type='ineq'`` dictionaries, matching the
+SciPy-style interface that ``minimize_ipopt`` accepts.
+
+The optional dependency ``cyipopt`` (PyPI name ``cyipopt``) provides the Ipopt
+binding; install with ``pip install cyipopt`` or via the ``ipopt`` extra.
+"""
+
+from collections.abc import Callable
+
+import numpy as np
+
+from minilink.optimization.mathematical_program import (
+    MathematicalProgram,
+    OptimizationResult,
+)
+from minilink.optimization.optimizers.optimizer import Optimizer
+
+
+class IpoptOptimizer(Optimizer):
+    """
+    Optimizer adapter for :func:`cyipopt.minimize_ipopt`.
+
+    Parameters
+    ----------
+    options : dict, optional
+        Ipopt options forwarded to :func:`cyipopt.minimize_ipopt`. The ``disp``
+        and ``maxiter`` keys are remapped to ``print_level`` / ``max_iter`` by
+        cyipopt; any other key is passed straight through to Ipopt (see
+        https://coin-or.github.io/Ipopt/OPTIONS.html).
+    tol : float, optional
+        Relative convergence tolerance forwarded to Ipopt as the ``tol`` option.
+
+    Notes
+    -----
+    Ipopt expects ``g(x) >= 0`` for inequality constraints, the same convention
+    used by :class:`~minilink.optimization.mathematical_program.MathematicalProgram`,
+    so margins are passed through unchanged.
+    """
+
+    def __init__(self, options: dict | None = None, tol: float | None = None):
+        self.options = {} if options is None else dict(options)
+        self.tol = tol
+
+    def _solve_impl(
+        self,
+        program: MathematicalProgram,
+        *,
+        callback: Callable[[object], None] | None = None,
+    ) -> OptimizationResult:
+        """Solve ``program`` with Ipopt and return a backend-neutral result."""
+        try:
+            from cyipopt import minimize_ipopt
+        except ImportError as exc:  # pragma: no cover - optional dep
+            raise ImportError(
+                "IpoptOptimizer requires the optional 'cyipopt' package; "
+                "install with `pip install cyipopt`."
+            ) from exc
+
+        constraints = []
+
+        # Equality constraints
+        for equality in program.equalities:
+            entry = {"type": "eq", "fun": equality.residual}
+            if equality.jac is not None:
+                entry["jac"] = equality.jac
+            constraints.append(entry)
+
+        # Inequality constraints
+        for inequality in program.inequalities:
+            entry = {"type": "ineq", "fun": inequality.margin}
+            if inequality.jac is not None:
+                entry["jac"] = inequality.jac
+            constraints.append(entry)
+
+        # Box bounds
+        bounds = None
+        if program.bounds is not None:
+            lower = (
+                np.full(program.n_z, -np.inf)
+                if program.bounds.lower is None
+                else program.bounds.lower
+            )
+            upper = (
+                np.full(program.n_z, np.inf)
+                if program.bounds.upper is None
+                else program.bounds.upper
+            )
+            bounds = list(zip(lower, upper))
+
+        raw_result = minimize_ipopt(
+            program.objective,
+            program.z0,
+            jac=program.gradient if program.grad is not None else None,
+            hess=program.hessian if program.hess is not None else None,
+            bounds=bounds,
+            constraints=constraints,
+            tol=self.tol,
+            options=dict(self.options),
+        )
+
+        stats = {}
+        for name in ("nit", "nfev", "njev", "status"):
+            if hasattr(raw_result, name):
+                stats[name] = getattr(raw_result, name)
+
+        cost = None
+        if getattr(raw_result, "fun", None) is not None:
+            cost = float(raw_result.fun)
+
+        return OptimizationResult(
+            z=np.asarray(raw_result.x, dtype=float),
+            success=bool(raw_result.success),
+            cost=cost,
+            message=str(raw_result.message),
+            stats=stats,
+            raw_result=raw_result,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ jax = [
     "jax>=0.4.28",
     "jaxlib>=0.4.28",
 ]
+ipopt = [
+    "cyipopt>=1.3",
+]
 
 [tool.ruff]
 line-length = 88

--- a/tests/benchmark/benchmark_optimizer_backends.py
+++ b/tests/benchmark/benchmark_optimizer_backends.py
@@ -1,0 +1,41 @@
+"""Manual optimizer-backend benchmark runner.
+
+Run from the repository root::
+
+    python tests/benchmark/benchmark_optimizer_backends.py
+    python tests/benchmark/benchmark_optimizer_backends.py --maxiter 500 --runs 3
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from minilink.optimization.benchmark import (
+    STANDARD_OPTIMIZATION_CASES,
+    benchmark_optimizer_backends,
+    default_optimizer_variants,
+    ipopt_optimizer_available,
+    print_optimizer_benchmark,
+)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--maxiter", type=int, default=200)
+parser.add_argument("--ftol", type=float, default=1e-8)
+parser.add_argument("--tol", type=float, default=1e-8)
+parser.add_argument("--runs", type=int, default=1)
+args = parser.parse_args()
+
+if not ipopt_optimizer_available():
+    print("note: cyipopt is not installed; running SciPy variants only.")
+
+variants = default_optimizer_variants(
+    maxiter=args.maxiter,
+    ftol=args.ftol,
+    tol=args.tol,
+)
+result = benchmark_optimizer_backends(
+    STANDARD_OPTIMIZATION_CASES,
+    variants,
+    n_runs=args.runs,
+)
+print_optimizer_benchmark(result)

--- a/tests/unittest/test_ipopt_optimizer.py
+++ b/tests/unittest/test_ipopt_optimizer.py
@@ -1,0 +1,110 @@
+"""Unit tests for :class:`IpoptOptimizer`.
+
+These tests require the optional ``cyipopt`` package and are skipped when it
+is not installed.
+"""
+
+import numpy as np
+import pytest
+
+from minilink.optimization.mathematical_program import (
+    EqualityConstraint,
+    InequalityConstraint,
+    MathematicalProgram,
+    VariableBounds,
+)
+
+cyipopt = pytest.importorskip("cyipopt")
+
+from minilink.optimization.optimizers.ipopt import IpoptOptimizer  # noqa: E402
+
+_QUIET = {"print_level": 0, "max_iter": 200}
+
+
+def test_ipopt_unconstrained_quadratic():
+    def J(z: np.ndarray) -> float:
+        return float(0.5 * np.sum((z - np.array([1.0, 2.0])) ** 2))
+
+    def grad(z: np.ndarray) -> np.ndarray:
+        return z - np.array([1.0, 2.0])
+
+    prog = MathematicalProgram(J=J, grad=grad, z0=np.zeros(2))
+    out = IpoptOptimizer(options=_QUIET).solve(prog)
+    assert out.success
+    assert np.allclose(out.z, [1.0, 2.0], atol=1e-6)
+    assert out.cost is not None and out.cost < 1e-10
+
+
+def test_ipopt_box_bounds():
+    def J(z: np.ndarray) -> float:
+        return float(0.5 * np.sum(z**2))
+
+    def grad(z: np.ndarray) -> np.ndarray:
+        return z
+
+    bounds = VariableBounds(lower=np.ones(3), upper=np.full(3, np.inf))
+    prog = MathematicalProgram(J=J, grad=grad, z0=2.0 * np.ones(3), bounds=bounds)
+    out = IpoptOptimizer(options=_QUIET).solve(prog)
+    assert out.success
+    assert np.allclose(out.z, np.ones(3), atol=1e-6)
+
+
+def test_ipopt_equality_constraint():
+    # min z0 + z1 s.t. z0^2 + z1^2 = 1  =>  z* = (-1,-1)/sqrt(2)
+    def J(z: np.ndarray) -> float:
+        return float(z[0] + z[1])
+
+    def grad(z: np.ndarray) -> np.ndarray:
+        return np.array([1.0, 1.0])
+
+    eq = EqualityConstraint(
+        h=lambda z: np.array([z[0] ** 2 + z[1] ** 2 - 1.0]),
+        jac=lambda z: np.array([[2.0 * z[0], 2.0 * z[1]]]),
+        name="circle",
+    )
+    prog = MathematicalProgram(
+        J=J, grad=grad, z0=np.array([-0.5, -0.5]), equalities=(eq,)
+    )
+    out = IpoptOptimizer(options=_QUIET).solve(prog)
+    assert out.success
+    assert np.allclose(out.z, [-1.0 / np.sqrt(2.0), -1.0 / np.sqrt(2.0)], atol=1e-5)
+
+
+def test_ipopt_inequality_with_bounds():
+    # min (z0-2)^2 + (z1-1)^2 s.t. z0 + z1 <= 1, z >= 0  =>  z* = (1, 0)
+    def J(z: np.ndarray) -> float:
+        return float((z[0] - 2.0) ** 2 + (z[1] - 1.0) ** 2)
+
+    def grad(z: np.ndarray) -> np.ndarray:
+        return np.array([2.0 * (z[0] - 2.0), 2.0 * (z[1] - 1.0)])
+
+    ineq = InequalityConstraint(
+        g=lambda z: np.array([1.0 - z[0] - z[1]]),
+        jac=lambda z: np.array([[-1.0, -1.0]]),
+        name="sum_le_one",
+    )
+    bounds = VariableBounds(lower=np.zeros(2), upper=np.full(2, np.inf))
+    prog = MathematicalProgram(
+        J=J,
+        grad=grad,
+        z0=np.array([0.5, 0.5]),
+        bounds=bounds,
+        inequalities=(ineq,),
+    )
+    out = IpoptOptimizer(options=_QUIET).solve(prog)
+    assert out.success
+    assert np.allclose(out.z, [1.0, 0.0], atol=1e-4)
+
+
+def test_ipopt_record_solve_time():
+    def J(z: np.ndarray) -> float:
+        return float(z[0] ** 2)
+
+    def grad(z: np.ndarray) -> np.ndarray:
+        return np.array([2.0 * float(z[0])])
+
+    prog = MathematicalProgram(J=J, grad=grad, z0=np.array([1.0]))
+    opt = IpoptOptimizer(options=_QUIET)
+    out = opt.solve(prog, record_solve_time=True)
+    assert out.success
+    assert out.solve_time_s is not None and out.solve_time_s >= 0.0

--- a/tests/unittest/test_optimizer_benchmark.py
+++ b/tests/unittest/test_optimizer_benchmark.py
@@ -1,0 +1,43 @@
+"""Smoke tests for :mod:`minilink.optimization.benchmark`."""
+
+import numpy as np
+
+from minilink.optimization.benchmark import (
+    OptimizerBenchmarkVariant,
+    STANDARD_OPTIMIZATION_CASES,
+    benchmark_optimizer_backends,
+    print_optimizer_benchmark,
+)
+
+
+def test_standard_cases_build_and_run_with_scipy():
+    variants = (
+        OptimizerBenchmarkVariant(
+            name="scipy-SLSQP",
+            backend="scipy",
+            method="SLSQP",
+            options={"maxiter": 200, "ftol": 1e-9, "disp": False},
+        ),
+    )
+    result = benchmark_optimizer_backends(STANDARD_OPTIMIZATION_CASES, variants)
+    assert len(result.rows) == len(STANDARD_OPTIMIZATION_CASES)
+    for row in result.rows:
+        assert row.solve_s >= 0.0
+        if row.cost_err is not None:
+            assert np.isfinite(row.cost_err)
+
+
+def test_print_optimizer_benchmark_does_not_crash(capsys):
+    variants = (
+        OptimizerBenchmarkVariant(
+            name="scipy-SLSQP",
+            backend="scipy",
+            method="SLSQP",
+            options={"maxiter": 200, "ftol": 1e-9, "disp": False},
+        ),
+    )
+    result = benchmark_optimizer_backends(STANDARD_OPTIMIZATION_CASES, variants)
+    print_optimizer_benchmark(result)
+    captured = capsys.readouterr()
+    assert "optimizer-backend benchmark" in captured.out
+    assert "case" in captured.out


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a second optimizer backend to `minilink.optimization`, based on the [cyipopt](https://cyipopt.readthedocs.io/stable/) Python binding for COIN-OR Ipopt, and a small benchmark module that compares it against the existing SciPy `minimize` backend on a fixed set of textbook nonlinear-program test cases.

The work stays inside the `optimization/` package and follows the same architecture as `compile/benchmark.py`, `simulation/benchmark.py`, and `planning/trajectory_optimization/benchmark.py`.

## Changes

- `minilink/optimization/optimizers/ipopt.py` — new `IpoptOptimizer` that wraps `cyipopt.minimize_ipopt` behind the same `Optimizer` contract used by `ScipyMinimizeOptimizer`. Supports objective gradient, Hessian, equality (`h(z) = 0`) and inequality (`g(z) >= 0`) constraints with optional Jacobians, and box bounds.
- `minilink/optimization/benchmark.py` — new module mirroring the layout of `simulation/benchmark.py`:
  - `OptimizerBenchmarkVariant`, `OptimizerBenchmarkCase`, `OptimizerBenchmarkRow`, `OptimizerBenchmarkResult` records.
  - `default_optimizer_variants()` (SciPy SLSQP, SciPy trust-constr, Ipopt when available) and `STANDARD_OPTIMIZATION_CASES` (unconstrained quadratic, Rosenbrock, box-constrained QP, equality circle, inequality QP).
  - `benchmark_optimizer_backends(...)` and `print_optimizer_benchmark(...)`.
- `tests/benchmark/benchmark_optimizer_backends.py` — flat `argparse` runner script in the same style as `benchmark_trajopt_backends.py`.
- `tests/unittest/test_ipopt_optimizer.py`, `tests/unittest/test_optimizer_benchmark.py` — unit tests; the Ipopt tests are skipped when `cyipopt` is not installed.
- `pyproject.toml` — declares an optional `ipopt` extra (`cyipopt>=1.3`).
- `DESIGN.md` — registers the new files in the optimization tree and adds an entry for the new benchmark module in §4.6.

## Notes

- The `MathematicalProgram` convention `g(z) >= 0` matches Ipopt's lower-bound-only form, so margins are passed straight through with no sign flip.
- The benchmark deliberately rebuilds the program for every (case, variant, run) so optimizers do not see warmed-up internal state.
- `cyipopt` itself depends on the system Ipopt headers (`coinor-libipopt-dev` / `pkg-config`), so it is intentionally an optional extra rather than a core dependency.

## Walkthrough

Sample output from `python tests/benchmark/benchmark_optimizer_backends.py` (SciPy SLSQP, SciPy trust-constr, Ipopt; one run; 5 textbook NLPs):

[optimizer_benchmark_run.log](https://cursor.com/agents/bc-5a519b07-51e1-4c53-9ce3-f6227804672e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foptimizer_benchmark_run.log)

## Testing

- `pytest tests/unittest/test_ipopt_optimizer.py tests/unittest/test_optimizer_benchmark.py tests/unittest/test_optimizer_solve_time.py` &mdash; 10 passed.
- `pytest tests/unittest/ --ignore=tests/unittest/test_jax_direct_collocation.py` &mdash; 113 passed, 25 skipped (pre-existing JAX/SymPy/visualization optional skips).
- Manual: `python tests/benchmark/benchmark_optimizer_backends.py` &mdash; all 3 backends solve all 5 cases successfully.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a519b07-51e1-4c53-9ce3-f6227804672e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a519b07-51e1-4c53-9ce3-f6227804672e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

