### PR TITLE
PR 2: Use pytest.importorskip for JAX-only test files

### DIFF
--- a/tests/unittest/test_jax_direct_collocation.py
+++ b/tests/unittest/test_jax_direct_collocation.py
@@ -5,56 +5,53 @@ import unittest
 import numpy as np
 import pytest
 
-try:
-    import jax
-    import jax.numpy as jnp
+pytest.importorskip("jax")
 
-    from minilink.compile.jax_utils import configure_jax
-    from minilink.core.costs import JaxQuadraticCost, QuadraticCost
-    from minilink.core.system import DynamicSystem
-    from minilink.dynamics.catalog.pendulum.cartpole import CartPole, JaxCartPole
-    from minilink.optimization.optimizers.scipy_minimize import ScipyMinimizeOptimizer
-    from minilink.planning.initial_guess import default_initial_trajectory
-    from minilink.planning.problems import PlanningProblem
-    from minilink.planning.trajectory_optimization.jax_direct_collocation import (
-        JaxDirectCollocationOptions,
-        JaxDirectCollocationTranscription,
-    )
-    from minilink.planning.trajectory_optimization.jax_multiple_shooting import (
-        JaxMultipleShootingOptions,
-        JaxMultipleShootingTranscription,
-    )
-    from minilink.planning.trajectory_optimization.jax_shooting import (
-        JaxShootingOptions,
-        JaxShootingTranscription,
-    )
-    from minilink.planning.trajectory_optimization.planner import (
-        TrajectoryOptimizationOptions,
-        TrajectoryOptimizationPlanner,
-    )
+import jax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
 
-    class JaxSingleIntegrator(DynamicSystem):
-        def __init__(self):
-            super().__init__(n=1, m=1, p=1)
-            self.state.lower_bound = np.array([-10.0])
-            self.state.upper_bound = np.array([10.0])
-            self.inputs["u"].lower_bound = np.array([-10.0])
-            self.inputs["u"].upper_bound = np.array([10.0])
+from minilink.compile.jax_utils import configure_jax  # noqa: E402
+from minilink.core.costs import JaxQuadraticCost, QuadraticCost  # noqa: E402
+from minilink.core.system import DynamicSystem  # noqa: E402
+from minilink.dynamics.catalog.pendulum.cartpole import CartPole, JaxCartPole  # noqa: E402
+from minilink.optimization.optimizers.scipy_minimize import ScipyMinimizeOptimizer  # noqa: E402
+from minilink.planning.initial_guess import default_initial_trajectory  # noqa: E402
+from minilink.planning.problems import PlanningProblem  # noqa: E402
+from minilink.planning.trajectory_optimization.jax_direct_collocation import (  # noqa: E402
+    JaxDirectCollocationOptions,
+    JaxDirectCollocationTranscription,
+)
+from minilink.planning.trajectory_optimization.jax_multiple_shooting import (  # noqa: E402
+    JaxMultipleShootingOptions,
+    JaxMultipleShootingTranscription,
+)
+from minilink.planning.trajectory_optimization.jax_shooting import (  # noqa: E402
+    JaxShootingOptions,
+    JaxShootingTranscription,
+)
+from minilink.planning.trajectory_optimization.planner import (  # noqa: E402
+    TrajectoryOptimizationOptions,
+    TrajectoryOptimizationPlanner,
+)
 
-        def f(self, x, u, t=0, params=None):
-            return jnp.array([u[0]])
 
-        def h(self, x, u, t=0, params=None):
-            return x
+class JaxSingleIntegrator(DynamicSystem):
+    def __init__(self):
+        super().__init__(n=1, m=1, p=1)
+        self.state.lower_bound = np.array([-10.0])
+        self.state.upper_bound = np.array([10.0])
+        self.inputs["u"].lower_bound = np.array([-10.0])
+        self.inputs["u"].upper_bound = np.array([10.0])
 
-    HAS_JAX = True
-except ImportError:
-    HAS_JAX = False
+    def f(self, x, u, t=0, params=None):
+        return jnp.array([u[0]])
+
+    def h(self, x, u, t=0, params=None):
+        return x
 
 
 @pytest.mark.optional
 @pytest.mark.jax
-@unittest.skipUnless(HAS_JAX, "jax not installed")
 class TestJaxDirectCollocation(unittest.TestCase):
     def setUp(self):
         configure_jax(enable_x64=True)

--- a/tests/unittest/test_mechanical_jax.py
+++ b/tests/unittest/test_mechanical_jax.py
@@ -5,23 +5,19 @@ import unittest
 import numpy as np
 import pytest
 
-try:
-    import jax
-    import jax.numpy as jnp
+pytest.importorskip("jax")
 
-    from minilink.dynamics.abstraction.mechanical import (
-        JaxMechanicalSystem,
-        MechanicalSystem,
-    )
+import jax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
 
-    HAS_JAX = True
-except ImportError:
-    HAS_JAX = False
+from minilink.dynamics.abstraction.mechanical import (  # noqa: E402
+    JaxMechanicalSystem,
+    MechanicalSystem,
+)
 
 
 @pytest.mark.optional
 @pytest.mark.jax
-@unittest.skipUnless(HAS_JAX, "jax not installed")
 class TestMechanicalSystemJax(unittest.TestCase):
     def test_f_is_jaxpr_traceable(self):
         sys = JaxMechanicalSystem(dof=2)

--- a/tests/unittest/test_physics_engine_jax.py
+++ b/tests/unittest/test_physics_engine_jax.py
@@ -5,28 +5,24 @@ import unittest
 import numpy as np
 import pytest
 
-try:
-    import jax
-    import jax.numpy as jnp
+pytest.importorskip("jax")
 
-    from minilink.physics.engine_jax import (
-        PlaneModel,
-        SphereModel,
-        make_world_model,
-        pack_state,
-        plane_contact_force,
-        unpack_state,
-        world_ode,
-    )
+import jax  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
 
-    HAS_JAX = True
-except ImportError:
-    HAS_JAX = False
+from minilink.physics.engine_jax import (  # noqa: E402
+    PlaneModel,
+    SphereModel,
+    make_world_model,
+    pack_state,
+    plane_contact_force,
+    unpack_state,
+    world_ode,
+)
 
 
 @pytest.mark.optional
 @pytest.mark.jax
-@unittest.skipUnless(HAS_JAX, "jax not installed")
 class TestPhysicsEngineJax(unittest.TestCase):
     def _single_world(self):
         return make_world_model(

--- a/tests/unittest/test_physics_system_minilink.py
+++ b/tests/unittest/test_physics_system_minilink.py
@@ -7,20 +7,20 @@ import pytest
 
 from minilink.core.diagram import DiagramSystem
 
-try:
-    import jax.numpy as jnp
+pytest.importorskip("jax")
 
-    from minilink.physics.engine_jax import PlaneModel, SphereModel, make_world_model
-    from minilink.physics.system import PhysicsWorldSystem
+import jax.numpy as jnp  # noqa: E402
 
-    HAS_JAX = True
-except ImportError:
-    HAS_JAX = False
+from minilink.physics.engine_jax import (  # noqa: E402
+    PlaneModel,
+    SphereModel,
+    make_world_model,
+)
+from minilink.physics.system import PhysicsWorldSystem  # noqa: E402
 
 
 @pytest.mark.optional
 @pytest.mark.jax
-@unittest.skipUnless(HAS_JAX, "jax not installed")
 class TestPhysicsSystemMinilink(unittest.TestCase):
     def _make_sys(self):
         world = make_world_model(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Step **PR 2** of `implementation_plan.md`. Replace the `try/except ImportError` + `@unittest.skipUnless(HAS_JAX, ...)` gating in JAX-only test files with `pytest.importorskip("jax")` at module top.

## Why

`tests/unittest/test_jax_direct_collocation.py` referenced `JaxQuadraticCost` as a default argument on a method (`make_single_integrator_problem(self, cost_cls=JaxQuadraticCost)`) outside the `try: import jax` block. Without JAX installed, the default-argument expression raised `NameError` during class-body evaluation, **before** `skipUnless` could fire &mdash; so collection errored out.

`pytest.importorskip("jax")` runs at module-import time, before any class body, so the file is cleanly **skipped** when JAX is missing.

## Scope

Same conversion applied to all four JAX-only test files for one-pattern uniformity:

- `tests/unittest/test_jax_direct_collocation.py` (the original bug)
- `tests/unittest/test_mechanical_jax.py`
- `tests/unittest/test_physics_engine_jax.py`
- `tests/unittest/test_physics_system_minilink.py`

`@pytest.mark.optional` / `@pytest.mark.jax` markers are preserved; redundant `@unittest.skipUnless(HAS_JAX, ...)` decorators removed.

## Out of scope

- `tests/unittest/test_simulator.py`, `test_compile_pipeline.py`, `test_simulation_speed_benchmarks.py`, `test_symbolic.py` &mdash; these interleave NumPy and JAX cases per-test method (no JAX symbol leaks into class-body / parse-time code), so per-method `@skipUnless(HAS_JAX, ...)` is correct there. Not touched.
- No production code changes.

## Testing

- ✅ Without JAX: `pytest tests/unittest/` &mdash; **106 passed, 19 skipped, 0 collection errors**.
- ✅ With JAX: `pytest tests/unittest/` &mdash; **130 passed, 7 skipped** (matches pre-PR baseline).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a519b07-51e1-4c53-9ce3-f6227804672e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a519b07-51e1-4c53-9ce3-f6227804672e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

