### PR TITLE
PR 4: Add minilink/compile/backend_policy.py + migrate call sites

### DIFF
--- a/minilink/compile/backend_policy.py
+++ b/minilink/compile/backend_policy.py
@@ -1,0 +1,95 @@
+"""
+Central vocabulary for compile-backend strings.
+
+One source of truth shared by :class:`~minilink.simulation.simulator.Simulator`,
+:class:`~minilink.planning.trajectory_optimization.planner.TrajectoryOptimizationOptions`,
+:func:`minilink.compile.compiler.compile`, and the benchmark modules. Avoids
+drift in the meaning of ``"numpy"`` / ``"jax"`` / ``"auto"`` / ``"direct"``
+across the library.
+
+Backend strings
+---------------
+
+================ ============================================================
+``"numpy"``      NumPy evaluator. Always available.
+``"jax"``        JAX evaluator. Hard-requires the ``minilink[jax]`` extra.
+``"auto"``       Try JAX, fall back to NumPy. Used by the simulator.
+``"direct"``     Use ``system.f`` directly (no compiled evaluator); valid for
+                 some trajectory-optimization transcriptions.
+================ ============================================================
+
+Notes
+-----
+``"auto"`` and ``"direct"`` are *transcription* / *simulator* concepts: the
+low-level :func:`minilink.compile.compiler.compile` only accepts ``"numpy"``
+and ``"jax"``. Use :func:`normalize_backend` with ``allow_auto`` /
+``allow_direct`` to validate at the right layer.
+"""
+
+from __future__ import annotations
+
+BACKEND_NUMPY = "numpy"
+BACKEND_JAX = "jax"
+BACKEND_AUTO = "auto"
+BACKEND_DIRECT = "direct"
+
+#: Backends accepted by :func:`minilink.compile.compiler.compile`.
+COMPILE_BACKENDS: tuple[str, ...] = (BACKEND_NUMPY, BACKEND_JAX)
+
+#: Backends accepted by :class:`~minilink.simulation.simulator.Simulator`.
+SIMULATOR_BACKENDS: tuple[str, ...] = (BACKEND_NUMPY, BACKEND_JAX, BACKEND_AUTO)
+
+#: Backends accepted by JAX trajectory-optimization transcriptions.
+TRANSCRIPTION_BACKENDS: tuple[str, ...] = (
+    BACKEND_NUMPY,
+    BACKEND_JAX,
+    BACKEND_DIRECT,
+)
+
+
+def normalize_backend(
+    name: str | None,
+    *,
+    allow_auto: bool = False,
+    allow_direct: bool = False,
+) -> str:
+    """Validate and lowercase a compile-backend string.
+
+    Parameters
+    ----------
+    name : str or None
+        Backend identifier. ``None`` is treated as ``"numpy"``.
+    allow_auto : bool, optional
+        Allow the ``"auto"`` value (Simulator-level concept).
+    allow_direct : bool, optional
+        Allow the ``"direct"`` value (transcription-level concept).
+
+    Returns
+    -------
+    str
+        Normalized lowercase backend string.
+    """
+    if name is None:
+        return BACKEND_NUMPY
+    key = str(name).strip().lower()
+    valid = list(COMPILE_BACKENDS)
+    if allow_auto:
+        valid.append(BACKEND_AUTO)
+    if allow_direct:
+        valid.append(BACKEND_DIRECT)
+    if key not in valid:
+        raise ValueError(
+            f"Unknown compile backend {name!r}. Expected one of {tuple(valid)}."
+        )
+    return key
+
+
+def require_jax_backend() -> None:
+    """Raise :class:`ImportError` with the canonical install hint if JAX is missing."""
+    try:
+        import jax  # noqa: F401
+    except ImportError as exc:
+        raise ImportError(
+            "This code path requires JAX. "
+            "Install with `pip install minilink[jax]` (or `pip install jax jaxlib`)."
+        ) from exc

--- a/minilink/compile/compiler.py
+++ b/minilink/compile/compiler.py
@@ -23,6 +23,12 @@ import copy
 import time
 from typing import TYPE_CHECKING
 
+from minilink.compile.backend_policy import (
+    BACKEND_JAX,
+    BACKEND_NUMPY,
+    normalize_backend,
+    require_jax_backend,
+)
 from minilink.compile.execution_plan import (
     EXTERNAL_INPUT,
     INTERNAL_SIGNAL,
@@ -37,7 +43,7 @@ if TYPE_CHECKING:
 
 
 # Public API
-def compile(system, backend="numpy", verbose=False):
+def compile(system, backend=BACKEND_NUMPY, verbose=False):
     """Compile a System into a :class:`DynamicsEvaluator`.
 
     For leaf systems (non-diagram), wraps ``f``/``h`` with frozen params
@@ -64,33 +70,24 @@ def compile(system, backend="numpy", verbose=False):
     if isinstance(system, DiagramSystem):
         return compile_diagram(system, backend=backend, verbose=verbose)
 
-    key = backend.strip().lower()
-    if key == "numpy":
+    key = normalize_backend(backend)
+    if key == BACKEND_NUMPY:
         from minilink.compile.evaluators.numpy_evaluator import NumpyLeafEvaluator
 
         return NumpyLeafEvaluator(system)
-    elif key == "jax":
-        try:
-            import jax  # noqa: F401
-        except ImportError:
-            raise ImportError(
-                "JAX is required for the 'jax' backend. "
-                "Install with: pip install jax jaxlib"
-            )
-        from minilink.compile.evaluators.jax_evaluator import JaxLeafEvaluator
+    require_jax_backend()
+    from minilink.compile.evaluators.jax_evaluator import JaxLeafEvaluator
 
-        t_total = time.perf_counter()
-        evaluator = JaxLeafEvaluator(system, verbose=verbose)
-        if verbose:
-            print(f"[compile] Done.  ({time.perf_counter() - t_total:.3f}s total)")
-        return evaluator
-    else:
-        raise ValueError(f"Unknown backend {backend!r}. Expected 'numpy' or 'jax'.")
+    t_total = time.perf_counter()
+    evaluator = JaxLeafEvaluator(system, verbose=verbose)
+    if verbose:
+        print(f"[compile] Done.  ({time.perf_counter() - t_total:.3f}s total)")
+    return evaluator
 
 
 def compile_diagram(
     diagram: DiagramSystem,
-    backend: str = "numpy",
+    backend: str = BACKEND_NUMPY,
     *,
     bind_params: bool = False,
     verbose: bool = False,
@@ -159,24 +156,17 @@ def compile_diagram(
         print(f"  ({time.perf_counter() - t0:.3f}s)")
 
     # Create evaluator (steps 0, 3, 4 handled inside for JAX)
-    key = backend.strip().lower()
-    if key == "numpy":
+    key = normalize_backend(backend)
+    if key == BACKEND_NUMPY:
         from minilink.compile.evaluators.numpy_evaluator import NumpyDiagramEvaluator
 
         evaluator = NumpyDiagramEvaluator(plan, diagram)
-    elif key == "jax":
-        try:
-            import jax  # noqa: F401
-        except ImportError:
-            raise ImportError(
-                "JAX is required for the 'jax' backend. "
-                "Install with: pip install jax jaxlib"
-            )
+    else:
+        # key == BACKEND_JAX (normalize_backend already validated)
+        require_jax_backend()
         from minilink.compile.evaluators.jax_evaluator import JaxDiagramEvaluator
 
         evaluator = JaxDiagramEvaluator(plan, diagram, verbose=verbose)
-    else:
-        raise ValueError(f"Unknown backend {backend!r}. Expected 'numpy' or 'jax'.")
 
     if verbose:
         print(f"[compile] Done.  ({time.perf_counter() - t_total:.3f}s total)")

--- a/minilink/planning/trajectory_optimization/planner.py
+++ b/minilink/planning/trajectory_optimization/planner.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 
 import numpy as np
 
+from minilink.compile.backend_policy import BACKEND_NUMPY
 from minilink.core.trajectory import Trajectory
 from minilink.optimization.mathematical_program import (
     MathematicalProgram,
@@ -40,7 +41,7 @@ class TrajectoryOptimizationOptions:
     ``disp=…`` (Minilink text report, not SciPy's ``options['disp']``).
     """
 
-    compile_backend: str | None = "numpy"
+    compile_backend: str | None = BACKEND_NUMPY
     initial_guess: np.ndarray | Trajectory | None = None
     warm_start: bool = False
     record_history: bool = False

--- a/minilink/simulation/simulator.py
+++ b/minilink/simulation/simulator.py
@@ -15,6 +15,11 @@ import logging
 
 import numpy as np
 
+from minilink.compile.backend_policy import (
+    BACKEND_AUTO,
+    BACKEND_JAX,
+    BACKEND_NUMPY,
+)
 from minilink.core.trajectory import Trajectory
 from minilink.simulation.solvers.euler import EulerSolverBackend
 from minilink.simulation.solvers.rk4_fixed import RK4SolverBackend
@@ -72,7 +77,9 @@ _USER_SOLVER_MODES: dict[str, tuple[str, dict]] = {
 RK4_AUTO_MIN_TIME_POINTS = 10_000
 
 # Pass ``compile_backend=COMPILE_BACKEND_AUTO`` to try JAX first, then NumPy.
-COMPILE_BACKEND_AUTO = "auto"
+# Re-exported from :mod:`minilink.compile.backend_policy` so legacy callers
+# importing it from the simulator keep working.
+COMPILE_BACKEND_AUTO = BACKEND_AUTO
 
 
 def _time_grid_is_uniform(times: np.ndarray) -> bool:
@@ -124,7 +131,7 @@ class Simulator:
         dt=None,
         solver=None,
         verbose=True,
-        compile_backend="numpy",
+        compile_backend=BACKEND_NUMPY,
     ):
         self.verbose = verbose
         self.sys = sys
@@ -235,7 +242,7 @@ class Simulator:
         if sys.solver_info["discontinuous_behavior"]:
             return "scipy_stiff"
         if (
-            self.compile_backend == "jax"
+            self.compile_backend == BACKEND_JAX
             and self.n_pts >= RK4_AUTO_MIN_TIME_POINTS
             and _time_grid_is_uniform(self.times)
         ):
@@ -318,7 +325,7 @@ class Simulator:
         Compile with *compile_backend*, or if it is :data:`COMPILE_BACKEND_AUTO`, try JAX
         then NumPy.
         """
-        if compile_backend != COMPILE_BACKEND_AUTO:
+        if compile_backend != BACKEND_AUTO:
             return compile_backend, self._build_evaluator(sys, compile_backend)
 
         if self.verbose:
@@ -328,9 +335,9 @@ class Simulator:
         except ImportError:
             if self.verbose:
                 print("JAX not installed; using NumPy compile backend.")
-            return "numpy", self._build_evaluator(sys, "numpy")
+            return BACKEND_NUMPY, self._build_evaluator(sys, BACKEND_NUMPY)
         try:
-            return "jax", self._build_evaluator(sys, "jax")
+            return BACKEND_JAX, self._build_evaluator(sys, BACKEND_JAX)
         except Exception as exc:
             if self.verbose:
                 print(
@@ -340,7 +347,7 @@ class Simulator:
             logging.getLogger(__name__).debug(
                 "JAX compile failed, falling back to numpy", exc_info=True
             )
-            return "numpy", self._build_evaluator(sys, "numpy")
+            return BACKEND_NUMPY, self._build_evaluator(sys, BACKEND_NUMPY)
 
     def _validate_x0(self, x0, n):
         x0_arr = np.asarray(x0, dtype=float)

--- a/tests/unittest/test_backend_policy.py
+++ b/tests/unittest/test_backend_policy.py
@@ -1,0 +1,66 @@
+"""Tests for :mod:`minilink.compile.backend_policy`."""
+
+import importlib
+import pytest
+
+from minilink.compile.backend_policy import (
+    BACKEND_AUTO,
+    BACKEND_DIRECT,
+    BACKEND_JAX,
+    BACKEND_NUMPY,
+    COMPILE_BACKENDS,
+    SIMULATOR_BACKENDS,
+    TRANSCRIPTION_BACKENDS,
+    normalize_backend,
+    require_jax_backend,
+)
+
+
+def test_constants_have_expected_string_values():
+    assert BACKEND_NUMPY == "numpy"
+    assert BACKEND_JAX == "jax"
+    assert BACKEND_AUTO == "auto"
+    assert BACKEND_DIRECT == "direct"
+
+
+def test_compile_simulator_transcription_backend_sets():
+    assert set(COMPILE_BACKENDS) == {BACKEND_NUMPY, BACKEND_JAX}
+    assert set(SIMULATOR_BACKENDS) == {BACKEND_NUMPY, BACKEND_JAX, BACKEND_AUTO}
+    assert set(TRANSCRIPTION_BACKENDS) == {
+        BACKEND_NUMPY,
+        BACKEND_JAX,
+        BACKEND_DIRECT,
+    }
+
+
+def test_normalize_backend_lowercases_and_validates():
+    assert normalize_backend("NumPy") == BACKEND_NUMPY
+    assert normalize_backend(" JAX ") == BACKEND_JAX
+    assert normalize_backend(None) == BACKEND_NUMPY
+
+
+def test_normalize_backend_rejects_unknown():
+    with pytest.raises(ValueError):
+        normalize_backend("torch")
+
+
+def test_normalize_backend_auto_gated():
+    with pytest.raises(ValueError):
+        normalize_backend("auto")
+    assert normalize_backend("auto", allow_auto=True) == BACKEND_AUTO
+
+
+def test_normalize_backend_direct_gated():
+    with pytest.raises(ValueError):
+        normalize_backend("direct")
+    assert normalize_backend("direct", allow_direct=True) == BACKEND_DIRECT
+
+
+def test_require_jax_backend_passes_when_jax_installed():
+    pytest.importorskip("jax")
+    require_jax_backend()  # must not raise
+
+
+def test_simulator_re_exports_compile_backend_auto():
+    sim = importlib.import_module("minilink.simulation.simulator")
+    assert sim.COMPILE_BACKEND_AUTO == BACKEND_AUTO


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Step **PR 4** of `implementation_plan.md`. One source of truth for compile-backend strings, shared by `Simulator`, `TrajectoryOptimizationOptions`, `compile.compile`, and downstream code.

## New module

`minilink/compile/backend_policy.py`:

- `BACKEND_NUMPY = "numpy"`
- `BACKEND_JAX = "jax"`
- `BACKEND_AUTO = "auto"`
- `BACKEND_DIRECT = "direct"`
- `COMPILE_BACKENDS`, `SIMULATOR_BACKENDS`, `TRANSCRIPTION_BACKENDS` &mdash; the three valid sets at each layer.
- `normalize_backend(name, *, allow_auto=False, allow_direct=False)` &mdash; validate + lowercase. ``"auto"`` and ``"direct"`` are gated because they are simulator/transcription concepts, not compile-target concepts.
- `require_jax_backend()` &mdash; raises `ImportError` with the canonical install hint (`pip install minilink[jax]`).

## Migrated call sites

- `minilink/simulation/simulator.py` &mdash; literal `"numpy"`/`"jax"`/`"auto"` replaced with the `BACKEND_*` constants. `COMPILE_BACKEND_AUTO` is now a re-export of `BACKEND_AUTO`, so any legacy `from minilink.simulation.simulator import COMPILE_BACKEND_AUTO` keeps working unchanged.
- `minilink/compile/compiler.py` &mdash; `compile()` and `compile_diagram()` use `normalize_backend()` + `require_jax_backend()`. The duplicated `'JAX is required for the "jax" backend'` message is gone.
- `minilink/planning/trajectory_optimization/planner.py` &mdash; `TrajectoryOptimizationOptions.compile_backend` default is now `BACKEND_NUMPY` (string value unchanged).

## Tests

- `tests/unittest/test_backend_policy.py` covers constant values, set membership, `normalize_backend` lowercase / validation / auto / direct gating, `require_jax_backend` (skipped without JAX), and the simulator `COMPILE_BACKEND_AUTO` re-export.

## Testing

- ✅ With JAX: `pytest tests/unittest/` &mdash; **138 passed, 7 skipped** (130 baseline + 8 new policy tests).
- ⚠️ Without JAX: this branch alone still hits the pre-existing collection error in `test_jax_direct_collocation.py` (the `JaxQuadraticCost` default-arg `NameError`). That fix lives in **PR 2 (#15)**; merging PR 2 first restores the NumPy-only collection-clean property. PR 4 introduces no new collection hazard.

## Notes

- No public API change. `Simulator.__init__(compile_backend="numpy")` keeps working; `TrajectoryOptimizationOptions(compile_backend="numpy")` keeps working.
- `agent.md` &sect;3 / `DESIGN.md` updates referencing the new module are scheduled for the docs PR (PR 1+9).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a519b07-51e1-4c53-9ce3-f6227804672e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a519b07-51e1-4c53-9ce3-f6227804672e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

