### PR TITLE
PR 5: Centralize JaxQuadraticCost rule

### DIFF
--- a/minilink/core/costs.py
+++ b/minilink/core/costs.py
@@ -238,3 +238,23 @@ class JaxQuadraticCost(QuadraticCost):
         x_arr = jnp.asarray(x).reshape(self.xbar.shape)
         dx = x_arr - jnp.asarray(self.xbar)
         return dx.T @ jnp.asarray(self.S) @ dx
+
+
+def require_jax_traceable_cost(cost: CostFunction) -> None:
+    """
+    Raise :class:`ValueError` if *cost* is a quadratic cost but not JAX-traceable.
+
+    JAX trajectory-optimization transcriptions need cost functions whose
+    ``g`` / ``h`` trace through ``jax.numpy``. The plain
+    :class:`QuadraticCost` materializes Python floats and breaks the trace;
+    use :class:`JaxQuadraticCost` instead.
+
+    This is the single source of truth for the rule; the JAX trajopt
+    transcriptions all delegate here.
+    """
+    if isinstance(cost, QuadraticCost) and not isinstance(cost, JaxQuadraticCost):
+        raise ValueError(
+            "JAX trajectory optimization needs JAX-traceable cost functions in "
+            "the objective; for quadratic costs use JaxQuadraticCost instead "
+            "of QuadraticCost."
+        )

--- a/minilink/planning/trajectory_optimization/jax_direct_collocation.py
+++ b/minilink/planning/trajectory_optimization/jax_direct_collocation.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 
 import numpy as np
 
-from minilink.core.costs import CostFunction, JaxQuadraticCost, QuadraticCost
+from minilink.core.costs import CostFunction, require_jax_traceable_cost
 from minilink.core.sets import BoxInputSet, BoxSet, SingletonSet
 from minilink.core.trajectory import Trajectory
 from minilink.optimization.mathematical_program import (
@@ -72,15 +72,6 @@ class JaxDirectCollocationTranscription(DirectCollocationTranscription):
     def __init__(self, options: JaxDirectCollocationOptions):
         self.options = options
 
-    @staticmethod
-    def _validate_jax_traceable_quadratic_pairing(cost: CostFunction) -> None:
-        if isinstance(cost, QuadraticCost) and not isinstance(cost, JaxQuadraticCost):
-            raise ValueError(
-                "JAX direct collocation needs JAX-traceable cost functions in the "
-                "objective; for quadratic costs use JaxQuadraticCost instead of "
-                "QuadraticCost."
-            )
-
     def transcribe(
         self,
         problem: PlanningProblem,
@@ -93,7 +84,7 @@ class JaxDirectCollocationTranscription(DirectCollocationTranscription):
         import jax.numpy as jnp
 
         cost = problem.require_cost()
-        self._validate_jax_traceable_quadratic_pairing(cost)
+        require_jax_traceable_cost(cost)
         self._check_supported_sets(problem)
 
         return self._transcribe_core(

--- a/minilink/planning/trajectory_optimization/jax_multiple_shooting.py
+++ b/minilink/planning/trajectory_optimization/jax_multiple_shooting.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 import numpy as np
 
-from minilink.core.costs import CostFunction, JaxQuadraticCost, QuadraticCost
+from minilink.core.costs import CostFunction, require_jax_traceable_cost
 from minilink.core.sets import BoxInputSet, BoxSet, SingletonSet
 from minilink.core.trajectory import Trajectory
 from minilink.optimization.mathematical_program import (
@@ -207,12 +207,7 @@ class JaxMultipleShootingTranscription(MultipleShootingTranscription):
 
     @staticmethod
     def _check_supported_problem(problem: PlanningProblem, cost: CostFunction) -> None:
-        if isinstance(cost, QuadraticCost) and not isinstance(cost, JaxQuadraticCost):
-            raise ValueError(
-                "JAX multiple shooting needs JAX-traceable cost functions in the "
-                "objective; for quadratic costs use JaxQuadraticCost instead of "
-                "QuadraticCost."
-            )
+        require_jax_traceable_cost(cost)
 
         for label, boundary in (("X0", problem.X0), ("Xf", problem.Xf)):
             if boundary is not None and not isinstance(boundary, SingletonSet):

--- a/minilink/planning/trajectory_optimization/jax_shooting.py
+++ b/minilink/planning/trajectory_optimization/jax_shooting.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 
 import numpy as np
 
-from minilink.core.costs import CostFunction, JaxQuadraticCost, QuadraticCost
+from minilink.core.costs import CostFunction, require_jax_traceable_cost
 from minilink.core.sets import BoxInputSet, BoxSet, SingletonSet
 from minilink.core.trajectory import Trajectory
 from minilink.optimization.mathematical_program import (
@@ -272,11 +272,7 @@ class JaxShootingTranscription(ShootingTranscription):
 
     @staticmethod
     def _check_supported_problem(problem: PlanningProblem, cost: CostFunction) -> None:
-        if isinstance(cost, QuadraticCost) and not isinstance(cost, JaxQuadraticCost):
-            raise ValueError(
-                "JAX shooting needs JAX-traceable cost functions in the objective; "
-                "for quadratic costs use JaxQuadraticCost instead of QuadraticCost."
-            )
+        require_jax_traceable_cost(cost)
 
         if problem.Xf is not None and not isinstance(
             problem.Xf,

--- a/tests/unittest/test_require_jax_traceable_cost.py
+++ b/tests/unittest/test_require_jax_traceable_cost.py
@@ -1,0 +1,50 @@
+"""Tests for :func:`minilink.core.costs.require_jax_traceable_cost`."""
+
+import numpy as np
+import pytest
+
+from minilink.core.costs import (
+    CostFunction,
+    QuadraticCost,
+    require_jax_traceable_cost,
+)
+
+
+def _identity_quadratic() -> QuadraticCost:
+    return QuadraticCost(
+        Q=np.eye(2),
+        R=np.eye(1),
+        S=np.eye(2),
+        xbar=np.zeros(2),
+        ubar=np.zeros(1),
+    )
+
+
+def test_rejects_plain_quadratic_cost():
+    with pytest.raises(ValueError, match="JaxQuadraticCost"):
+        require_jax_traceable_cost(_identity_quadratic())
+
+
+def test_accepts_jax_quadratic_cost():
+    pytest.importorskip("jax")
+    from minilink.core.costs import JaxQuadraticCost
+
+    cost = JaxQuadraticCost(
+        Q=np.eye(2),
+        R=np.eye(1),
+        S=np.eye(2),
+        xbar=np.zeros(2),
+        ubar=np.zeros(1),
+    )
+    require_jax_traceable_cost(cost)  # must not raise
+
+
+def test_accepts_non_quadratic_cost():
+    class NoOpCost(CostFunction):
+        def g(self, x, u, t=0.0, params=None):
+            return 0.0
+
+        def h(self, x, t=0.0, params=None):
+            return 0.0
+
+    require_jax_traceable_cost(NoOpCost())  # must not raise (rule only gates QuadraticCost)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Step **PR 5** of `implementation_plan.md`. Three near-verbatim copies of the "JAX trajopt requires `JaxQuadraticCost`" check are replaced by delegation to one function.

## Why

Before this PR, the rule lived in:

- `minilink/planning/trajectory_optimization/jax_direct_collocation.py:76` (`_validate_jax_traceable_quadratic_pairing`)
- `minilink/planning/trajectory_optimization/jax_shooting.py:275` (`_check_supported_problem`)
- `minilink/planning/trajectory_optimization/jax_multiple_shooting.py:210` (`_check_supported_problem`)

Each had its own slightly different error string. Three places to update if the rule ever changes.

## Scope

- `minilink/core/costs.py` &mdash; new public function `require_jax_traceable_cost(cost)` next to `QuadraticCost` / `JaxQuadraticCost`.
- The three transcription modules now import and call `require_jax_traceable_cost(cost)`. Local validators are removed.
- `tests/unittest/test_require_jax_traceable_cost.py` exercises the validator directly: rejects plain `QuadraticCost`, accepts `JaxQuadraticCost` (when JAX is installed), and accepts non-quadratic `CostFunction` subclasses (the rule only gates `QuadraticCost`, by design).

## Testing

- ✅ `pytest tests/unittest/` &mdash; **133 passed, 7 skipped** (130 baseline + 3 new validator tests).
- ✅ `rg "JaxQuadraticCost instead" minilink/` &mdash; exactly **one hit**, in `minilink/core/costs.py`.
- ✅ Existing `tests/unittest/test_jax_direct_collocation.py::test_rejects_numpy_quadratic_cost` still passes (regex `"JaxQuadraticCost"` matches the new centralized message).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a519b07-51e1-4c53-9ce3-f6227804672e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a519b07-51e1-4c53-9ce3-f6227804672e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

