### PR TITLE
PR 1+9: Fold JAX/NumPy coexistence rules into agent.md, DESIGN.md, README

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -140,6 +140,15 @@ minilink/graphical/renderers/
 | Compiled dynamics | `evaluators/` | `evaluator.py` |
 | Draw / animate | `renderers/` | `renderer.py` |
 | Compile orchestration | `compile/` (root) | `compiler.py` (not `compilers/`) |
+| Backend strings (`"numpy"` / `"jax"` / `"auto"` / `"direct"`) | `compile/` (root) | `backend_policy.py` |
+
+**JAX twin classes.** When a plant or cost has a JAX-traceable counterpart
+(`Jax<X>`), it lives in the **same module** as the NumPy class, **subclasses**
+it, and overrides only the equation methods (`H`, `C`, `B`, `g`, `d`, `f`,
+`h`, custom force terms). JAX is loaded lazily via
+`minilink.compile.jax_utils.require_jax_numpy()`; importing the module stays
+free without the `minilink[jax]` extra. See `agent.md` §3.1 for the full
+five-rule policy and `plan.md` for the strategy background.
 
 ### 2.3 Canonical `minilink/` tree (reference)
 
@@ -409,11 +418,13 @@ It separates the continuous mathematical problem from numerical solver choices:
 - **JAX direct collocation (prototype)** —
   `trajectory_optimization.jax_direct_collocation` also targets SciPy, but
   uses JAX-``jit``/``jacfwd``/optional Hessian to supply objective and constraint
-  derivatives. The cost must be JAX-traceable in the objective (use
-  :class:`~minilink.core.costs.JaxQuadraticCost` instead of
-  :class:`~minilink.core.costs.QuadraticCost` for the common quadratic case).
-  Supported sets are **narrower** than the NumPy path: :class:`~minilink.core.sets.SingletonSet`
-  for :math:`X_0` / :math:`X_f` and box-style path sets via
+  derivatives. The cost must be JAX-traceable in the objective; the rule is
+  enforced by :func:`minilink.core.costs.require_jax_traceable_cost`, which
+  the three JAX transcriptions all delegate to. For the common quadratic
+  case use :class:`~minilink.core.costs.JaxQuadraticCost` instead of
+  :class:`~minilink.core.costs.QuadraticCost`. Supported sets are **narrower**
+  than the NumPy path: :class:`~minilink.core.sets.SingletonSet` for
+  :math:`X_0` / :math:`X_f` and box-style path sets via
   :class:`~minilink.core.sets.BoxSet` / :class:`~minilink.core.sets.BoxInputSet`;
   general set margins remain on the NumPy transcription until reviewed. JAX
   precision is process-wide compile configuration via
@@ -517,7 +528,7 @@ Current solver modes (see `minilink.simulation.simulator` and tests):
 - `solver="scipy_lsoda"` (alias that selects LSODA; useful for stiff/variable-tolerance cases)
 - **Auto RK4 (heuristic)**: for long, **uniform** time grids, JAX compile backend, and a non-stiff profile, the simulator may select `rk4_fixedsteps` automatically for wall-clock reasons. This is best-effort; defaults remain explicit where conservatism matters.
 
-`Simulator(..., compile_backend=...)` accepts `"numpy"`, `"jax"`, or **`"auto"`** (`minilink.simulation.COMPILE_BACKEND_AUTO`): try JAX, fall back to NumPy on failure. User-facing `System.compute_trajectory` / `compute_forced` default to **`"numpy"`** (predictable, no extra JIT) unless overridden.
+`Simulator(..., compile_backend=...)` accepts `"numpy"`, `"jax"`, or **`"auto"`**: try JAX, fall back to NumPy on failure. The string vocabulary is centralized in :mod:`minilink.compile.backend_policy` (constants `BACKEND_NUMPY`, `BACKEND_JAX`, `BACKEND_AUTO`, `BACKEND_DIRECT`; helpers `normalize_backend`, `require_jax_backend`); `minilink.simulation.COMPILE_BACKEND_AUTO` is a re-export of `BACKEND_AUTO` kept for back-compat. User-facing `System.compute_trajectory` / `compute_forced` default to **`"numpy"`** (predictable, no extra JIT) unless overridden.
 
 **SciPy preset tolerances** (`scipy`, `scipy_stiff`, …) pass explicit `rtol` / `atol` into `solve_ivp` so behavior is not left to global SciPy defaults.
 

--- a/README.md
+++ b/README.md
@@ -67,3 +67,7 @@ plot_trajectory(diagram, traj)
 - **Scripts**: `examples/scripts/` for diagram compilation, internal signals, animations, and JAX physics demos
 - **Manual**: `tests/manual/` for one-off experiments (pendulum `compute_forced` + `animate` smokes: see **Current State** above)
 - **Notebook**: [Colab Tutorial](https://colab.research.google.com/drive/13tnYyZMz4bLFzYLdj88H6cqO6tZg6Xp7?usp=sharing)
+
+### JAX vs NumPy
+
+Minilink runs end-to-end on NumPy alone. JAX is an optional accelerator: install with `pip install minilink[jax]` to unlock JAX-traced plants (`Jax<X>` classes), JIT-compiled simulator rollouts (`Simulator(..., compile_backend="jax"|"auto")`), and analytic gradients in trajectory optimization (`Jax*Transcription`). Without JAX, those classes still **import**; only their methods raise. The strategic background, twin-class rule, and migration roadmap live in [`plan.md`](plan.md) and [`implementation_plan.md`](implementation_plan.md); the five operational rules are summarized in [`agent.md`](agent.md) §3.1.

--- a/agent.md
+++ b/agent.md
@@ -66,6 +66,50 @@ Borrow the **scientific object model** and equation readability of the legacy Py
 - Support JAX when it stays clean; use specialized JAX paths when needed instead of complicating the main path.
 - **KISS and thin surfaces**: Prefer fewer files, fewer lines, and fewer dependencies when a simpler design is enough. When complexity is justified, keep **user-facing scripts and examples** minimal and push mechanics into backend modules or utilities.
 
+### 3.1 JAX vs NumPy coexistence (five rules)
+
+`pip install minilink` (no extras) gives a fully working **NumPy pipeline**;
+`pip install minilink[jax]` unlocks JAX-traced plants, JIT rollouts, and
+analytic gradients. Five rules keep that contract honest. The strategic
+background and trade-offs are in `plan.md`; the per-PR migration plan is in
+`implementation_plan.md`.
+
+1. **Plants and costs use twin classes (NumPy + `Jax<X>` subclass).** The JAX
+   class lives in the **same module** as the NumPy class, **subclasses** it,
+   and overrides only the equation methods (`H`, `C`, `B`, `g`, `d`, `f`,
+   `h`, custom force terms). Geometry, parameter dataclasses, port labels,
+   bounds, and visualization are inherited. References:
+   `JaxDynamicBicycle(DynamicBicycle)`, `JaxCartPole(JaxMechanicalSystem)`,
+   `JaxMechanicalSystem(MechanicalSystem)`, `JaxPendulum(NumpyPendulum)`,
+   `JaxQuadraticCost(QuadraticCost)`.
+2. **Backend roles use one ABC + two implementations.** Evaluators
+   (`compile/evaluators/{numpy_evaluator.py, jax_evaluator.py}` behind
+   `evaluator.py`) and trajectory-optimization transcriptions
+   (`direct_collocation.py` / `jax_direct_collocation.py`, etc.) follow this
+   shape. Backend selection goes through the constants in
+   `minilink.compile.backend_policy`; do not hard-code `"numpy"` /
+   `"jax"` / `"auto"` / `"direct"` strings elsewhere.
+3. **Thin helpers and blocks use array-module dispatch.** Code in
+   `core/blocks/*` and other small math helpers writes one body and
+   dispatches on the runtime input type via
+   `minilink.compile.jax_utils.array_module(t)`. Do **not** use
+   array-module dispatch inside complex plant `f`; plants get the twin-class
+   treatment.
+4. **Optional-import policy is two patterns, no more.** In library code,
+   either call `require_jax_numpy()` (or `require_jax_backend()` from
+   `compile.backend_policy`) lazily inside JAX-only methods, or use
+   `array_module(...)` for hybrid code. Never `import jax` at module level
+   in `minilink/`. Module-level `try/except ImportError + _HAS_JAX` is
+   reserved for **tests** and **runner scripts**, plus the documented
+   exception in `minilink/planning/trajectory_optimization/benchmark.py`
+   (its public contract is "skip JAX rows when JAX is missing").
+5. **Backend strings live in one place.** `BACKEND_NUMPY`, `BACKEND_JAX`,
+   `BACKEND_AUTO`, `BACKEND_DIRECT`, `normalize_backend(...)`, and
+   `require_jax_backend()` are defined in `minilink.compile.backend_policy`.
+   The `JaxQuadraticCost` rule is documented and enforced by
+   `minilink.core.costs.require_jax_traceable_cost`. JAX trajopt
+   transcriptions delegate; they do not re-implement either rule.
+
 Compiled-evaluator vocabulary:
 
 - `outputs()` / `outputs_p()` means **boundary outputs only**
@@ -83,6 +127,15 @@ At feature completion, verify through:
 1. **Automated tests** with `pytest`
 2. **Manual test script** in `tests/manual/`
 3. **Demo script** in `examples/` for major user-facing features
+
+**JAX twin plants** must additionally include a canonical
+`<plant>_jax_matches_numpy` test pair: one nominal / linear-regime
+match and one non-trivial regime check (custom inertia, gravity, damping,
+or a saturating force) so the JAX trace and the NumPy reference disagree
+at most by ULP-level rounding (with `configure_jax(enable_x64=True)`).
+References: `tests/unittest/test_jax_dynamic_bicycle.py`,
+`tests/unittest/test_jax_pendulum_subclass.py`,
+`tests/unittest/test_mechanical_jax.py::test_f_matches_numpy_2dof_nontrivial_regime`.
 
 ## 5. TRL Lifecycle
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Steps **PR 1** and **PR 9** of `implementation_plan.md` combined into one docs-only PR. Folds the five JAX/NumPy coexistence rules from `plan.md` &sect;3 into the day-to-day docs so the policy becomes quotable.

## Changes

### `agent.md`

- **New &sect;3.1 "JAX vs NumPy coexistence (five rules)"** &mdash; quotable summary of `plan.md` &sect;3 with concrete references (`JaxDynamicBicycle`, `JaxCartPole`, `JaxMechanicalSystem`, `JaxPendulum`, `JaxQuadraticCost`, `compile.backend_policy`, `require_jax_traceable_cost`, `array_module`). Documents the two allowed optional-import patterns and the `HAS_JAX_TRAJOPT` exception in the trajopt benchmark module.
- **&sect;4 (3-Level Verification)** &mdash; adds the requirement that every JAX twin plant ships a canonical `<plant>_jax_matches_numpy` test (linear + non-trivial regime), with references to `test_jax_dynamic_bicycle.py`, `test_jax_pendulum_subclass.py`, and `test_mechanical_jax.py::test_f_matches_numpy_2dof_nontrivial_regime`.

### `DESIGN.md`

- **&sect;2.2 (role-naming table)** &mdash; new row for the backend-string vocabulary (`compile/backend_policy.py`). Short paragraph documenting the JAX twin pattern (same module, subclass, overrides only equation methods, lazy import).
- **&sect;3.5 (trajectory optimization)** &mdash; the `JaxQuadraticCost` rule now cross-references `core.costs.require_jax_traceable_cost` instead of restating the rule.
- **&sect;4.5 (simulator)** &mdash; explicit reference to `compile.backend_policy` constants; `COMPILE_BACKEND_AUTO` is documented as a back-compat re-export.

### `README.md`

- **New "JAX vs NumPy" subsection under Examples** &mdash; one paragraph telling users that `pip install minilink` is enough for the NumPy pipeline and `pip install minilink[jax]` unlocks JAX. Cross-references `plan.md`, `implementation_plan.md`, and `agent.md` &sect;3.1.

## Notes

- These references rely on names introduced in earlier PRs: `compile.backend_policy` (PR 4 / #17) and `core.costs.require_jax_traceable_cost` (PR 5 / #18). Reviewers may prefer to merge those before this docs PR; the docs are still self-consistent on their own (the references are forward-looking).

## Testing

- ✅ `pytest tests/unittest/` &mdash; **130 passed, 7 skipped** (no behavior change).
- ✅ Documentation only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a519b07-51e1-4c53-9ce3-f6227804672e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a519b07-51e1-4c53-9ce3-f6227804672e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

