### PR TITLE
Add AGENTS.md for Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+minilink is a pure Python library (no external services, databases, or web servers). See `README.md` for capabilities and `DESIGN.md` for architecture.
+
+### Environment
+
+- **Python 3.10+** required (`pyproject.toml` specifies `>=3.10`).
+- System `graphviz` package must be installed (`apt install graphviz`) for the Python `graphviz` bindings to work.
+- Install dev dependencies: `pip install -e ".[dev]"` from the repo root.
+- Optional extras: `.[jax]`, `.[symbolic]`, `.[visualization]` — JAX tests are skipped gracefully if not installed.
+
+### Running tests and lint
+
+```bash
+# Lint
+ruff check .
+ruff format --check .
+
+# Tests (configured via pyproject.toml to use tests/unittest/)
+pytest
+```
+
+### Running examples/demos
+
+Example scripts live in `examples/scripts/`. Run from the repo root:
+
+```bash
+python examples/scripts/<script>.py
+```
+
+For headless environments, set `matplotlib.use('Agg')` before importing minilink graphical modules (or set `MPLBACKEND=Agg`). Animation demos (`animate()`) require a display; plotting/simulation works headless.
+
+### Gotchas
+
+- The `plot_graphe()` method may emit D-Bus errors in headless environments — these are harmless and do not affect output.
+- `plot_trajectory()` does not accept a `show` kwarg; to suppress display in scripts, use `matplotlib.use('Agg')` before importing.
+- The `agent.md` file references a `dev-h26` conda env for the maintainer's local machine. In cloud agents, use system Python 3.10+ with `pip install -e ".[dev]"` instead.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud-specific instructions for future cloud agents working on this codebase.

## What's included

- Environment setup notes (Python 3.10+, system graphviz, pip install)
- Commands for lint (`ruff check/format`) and tests (`pytest`)
- How to run example scripts headless
- Gotchas discovered during setup (D-Bus noise, `plot_trajectory` API, conda vs cloud venv)

## Verification

All development tasks work correctly in the cloud agent environment:

- **Lint**: `ruff check .` and `ruff format --check .` run successfully (pre-existing issues in repo)
- **Tests**: `pytest` — 74 passed, 22 skipped (JAX/SymPy optional)
- **Simulation**: Quick Start example and closed-loop pendulum PD control run and produce correct trajectories
- **Compile pipeline**: NumPy compiled evaluator matches baseline output

[Quick Start trajectory plot](https://cursor.com/agents/bc-6dc16c69-f694-471d-9b41-d2734d56dcf5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fquickstart_trajectory.png)
[Closed-loop pendulum trajectory](https://cursor.com/agents/bc-6dc16c69-f694-471d-9b41-d2734d56dcf5/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclosed_loop_pendulum.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6dc16c69-f694-471d-9b41-d2734d56dcf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6dc16c69-f694-471d-9b41-d2734d56dcf5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

