### PR TITLE
chore: gitignore Hatch-generated minilink/_version.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ share/python-wheels/
 .installed.cfg
 MANIFEST
 
+# Hatch VCS version file (generated; see pyproject.toml hatch.build.hooks.vcs)
+minilink/_version.py
+
 
 # Data etc #
 ############################


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Hatch’s VCS hook writes `minilink/_version.py` locally; the generated file already states it should not be tracked. Adding it to `.gitignore` avoids persistent untracked noise after builds and matches typical Hatch-VCS workflow.

No behavioral change to the package for installs from sdist/wheel (version still comes from tags at build time).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-509d1e60-5cc9-4c6b-83e4-2b4695ac8aab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-509d1e60-5cc9-4c6b-83e4-2b4695ac8aab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

