### PR TITLE
docs: TRL, benchmark paths, package tree, and dev env wording (dev-alex)

### DIFF
--- a/.cursor/rules/read-agent-first.mdc
+++ b/.cursor/rules/read-agent-first.mdc
@@ -11,4 +11,4 @@ alwaysApply: true
 - Exclude notebooks from normal review/style passes unless the task is only to update renamed imports/API names or the user explicitly asks for notebook cleanup. Never review notebook outputs by default.
 - If instructions in chat conflict with `agent.md`, ask for clarification before proceeding.
 - Avoid adding new guideline documents if the same guidance already exists in `agent.md`.
-- For terminal commands in this repo (tests, `examples/scripts`, benchmarks), use the **`dev-h26` conda** environment; see `agent.md` §7. Do not assume `/usr/bin/python3` is sufficient.
+- For terminal commands in this repo (tests, `examples/scripts`, benchmarks), use a Python **3.10+** interpreter with the optional extras you need (see `pyproject.toml`). Maintainers may document a shared conda env name for convenience; it is not fixed—see `agent.md` section 9 (Local Environment). Do not assume `/usr/bin/python3` is sufficient.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -85,6 +85,13 @@ minilink/
     initial_guess.py
     search/
     trajectory_optimization/
+      benchmark.py
+      direct_collocation.py
+      live_plot.py
+      multiple_shooting.py
+      planner.py
+      shooting.py
+      transcription.py
     policy_synthesis/
   dynamics/
     abstraction/
@@ -98,8 +105,17 @@ minilink/
     matplotlib_style.py
     renderers/
   symbolic/
+    mechanics/
+      derivation.py
+      export.py
+      model.py
+      symbolic_system.py
+      utils.py
   physics/
+    engine_jax.py
+    system.py
   control/
+    pendulum_pd.py
 ```
 
 ## 3. Core Object Contracts
@@ -370,8 +386,8 @@ Graphics:
 Benchmarks:
 
 - benchmark helpers live beside the subsystem they measure, for example
-  `compile/benchmark.py`, `simulation/benchmark.py`, and
-  `optimization/benchmark.py`;
+  `compile/benchmark.py`, `simulation/benchmark.py`,
+  `optimization/benchmark.py`, and `planning/trajectory_optimization/benchmark.py`;
 - runnable benchmark scripts live under `tests/benchmark/`;
 - benchmark helpers are not core contracts.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,7 +17,7 @@ This document tracks active priorities and maturity. Design contracts live in
 | Dynamics catalog | TRL 0-1 | Grow reviewed plants by domain. |
 | Symbolic/physics/control | TRL 0-1 | Keep MVP examples working; expand only behind clear use cases. |
 
-TRL definitions are in [agent.md](agent.md).
+TRL definitions are in [agent.md (section 8)](agent.md#8-trl-lifecycle).
 
 ## 2. Completed Architecture Work
 

--- a/agent.md
+++ b/agent.md
@@ -126,7 +126,9 @@ classes whose only purpose is to wrap simple traceable algebra.
 - `compile/compiler.py` is the compile orchestrator. Do not add
   `compile/compilers/`.
 - Benchmarks live beside the subsystem they measure, with runnable scripts under
-  `tests/benchmark/`.
+  `tests/benchmark/`. Import timing helpers from the defining package (for example
+  `minilink.compile.benchmark` or `minilink.simulation.benchmark`); there is no
+  top-level `minilink.benchmark` package.
 - Demo and manual scripts should stay flat, direct, and runnable from the repo
   root.
 
@@ -163,12 +165,41 @@ Ask first:
 If a small request turns into a large job after inspection, stop and explain the
 smallest useful slice.
 
-## 8. Local Environment
+## 8. TRL Lifecycle
 
-Use the `dev-h26` conda environment for tests, examples, and benchmarks.
+Readiness levels are an internal maturity scale for planning and review. They
+are not a release process by themselves.
+
+| Level | Name | Description |
+| --- | --- | --- |
+| **TRL 1** | Agent MVP | Initial code exists and works |
+| **TRL 2** | User-check MVP | User performs a high-level functional review |
+| **TRL 3** | Architecture Validated | High-level architecture is approved |
+| **TRL 4** | Integration Proposed | Final integration/refactor is proposed |
+| **TRL 5** | Integration Validated | User approves main-codebase integration |
+| **TRL 6** | Automated Tests Pass | Final pytest coverage exists and passes |
+| **TRL 7** | Details Validated | Naming and implementation details are approved |
+| **TRL 8** | Demo Released | Demo script is created and validated |
+| **TRL 9** | Mission Complete | Tests, demo, and user approval are all complete |
+
+The subsystem maturity matrix in `ROADMAP.md` uses these definitions.
+
+## 9. Local Environment
+
+The project targets **Python 3.10+** with optional extras for JAX, SymPy,
+visualization, and Ipopt (`pyproject.toml`). Do not rely on macOS
+`/usr/bin/python3` when it is older than 3.10 (for example `|` in type hints).
+
+Maintainers often use a **conda** environment for local development (for example
+named `dev-h26` on some machines). That environment name is **not contractual**:
+any equivalent setup—conda, venv, or another tool—with Python 3.10+ and the
+extras you need for the task is acceptable. Align optional dependency versions
+with CI or teammates when running tests, examples, and benchmarks.
+
+Example with conda (substitute your environment name):
 
 ```bash
-conda activate dev-h26
+conda activate dev-h26   # or your own env
 python -m pytest
 ```
 
@@ -176,8 +207,5 @@ From a fresh shell:
 
 ```bash
 conda run -n dev-h26 python -m pytest
-conda run -n dev-h26 python examples/scripts/demo_animations.py
+conda run -n dev-h26 python examples/scripts/animation/demo_animations.py
 ```
-
-Do not use macOS system Python for this repo; it may be too old for the project
-type syntax and optional dependency set.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

Documentation was out of sync with how the repo actually works on `dev-alex`:

- **TRL**: `ROADMAP.md` pointed at `agent.md` for TRL definitions, but that section did not exist. Added an **TRL lifecycle** table to `agent.md` (section 8) and linked `ROADMAP.md` to it with an anchor.
- **Local environment**: `dev-h26` was described as mandatory. Clarified that **Python 3.10+** and optional extras are the real requirement; conda env naming is an example and **not contractual**. Corrected the demo path to `examples/scripts/animation/demo_animations.py`.
- **Benchmark imports**: `agent.md` now states that helpers live under subsystem packages (`minilink.compile.benchmark`, `minilink.simulation.benchmark`, …) and there is **no** top-level `minilink.benchmark` package.
- **DESIGN.md**: Expanded the on-disk tree for `symbolic/mechanics/`, `physics/`, `control/`, and `planning/trajectory_optimization/` (including `benchmark.py`). §7 benchmark bullets mention trajopt benchmark helpers.
- **Cursor rule**: `.cursor/rules/read-agent-first.mdc` updated to match (Python 3.10+, env name not fixed, pointer to `agent.md` Local Environment).

### Files touched

- `agent.md`, `ROADMAP.md`, `DESIGN.md`, `.cursor/rules/read-agent-first.mdc`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-509d1e60-5cc9-4c6b-83e4-2b4695ac8aab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-509d1e60-5cc9-4c6b-83e4-2b4695ac8aab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

