### PR TITLE
Interactive 3D camera: apply transform once (matplotlib + meshcat)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -380,7 +380,8 @@ Camera / framing contract:
   camera matrix consumed by every renderer. There is one matrix and one method:
   2D rendering is always an orthographic projection of the same 3D camera (no
   separate 2D pipeline). Built by `minilink.graphical.primitives.camera_matrix`:
-  - `T[:3, 3]` look-at target in world (the view re-centers each frame);
+  - `T[:3, 3]` look-at target in world (each frame for 2D projection; initial
+    framing for interactive 3D);
   - columns of `T[:3, :3]` are world directions of camera-X (plot horizontal),
     camera-Y (plot vertical), camera-Z (view-out); built from `plot_axes=(i, j)`
     as `(e_i, e_j, e_i × e_j)` or supplied directly via `R=`;
@@ -391,9 +392,9 @@ Camera / framing contract:
   matplotlib 2D / pygame pre-multiply body transforms by `world_to_camera(camera)`
   so primitive XY ends up in camera frame, with `xlim/ylim = ±T[3,3]` and axis
   labels auto-derived from the dominant world axis; matplotlib 3D decodes
-  `view_init(elev, azim)` from `R[:,2]` and re-centers `xlim/ylim/zlim` each
-  frame; meshcat best-effort applies the orbit pivot per frame and the eye
-  distance once at scene open.
+  `view_init(elev, azim)` from `R[:,2]` and sets `xlim/ylim/zlim` once at scene
+  open, then leaves the interactive camera to the UI; meshcat sets orbit pivot
+  and eye distance once at scene open (same interactive-camera rule).
 - Intentional non-knobs (KISS): anisotropic per-axis zoom and field-of-view are
   not in the contract; `aspect='equal'` is enforced everywhere.
 

--- a/minilink/graphical/renderers/matplotlib_renderer.py
+++ b/minilink/graphical/renderers/matplotlib_renderer.py
@@ -33,7 +33,6 @@ from minilink.graphical.primitives import (
 )
 from minilink.graphical.renderers.renderer import AnimationRenderer
 
-
 _AXIS_LABEL_BY_INDEX = ("X", "Y", "Z")
 
 
@@ -429,8 +428,8 @@ class MatplotlibRenderer(AnimationRenderer):
         self.canvas.clear()
         # 2D path uses an orthographic projection onto the camera plane: pre-multiply
         # body transforms by world-to-camera so primitive XY is already in camera frame.
-        # 3D matplotlib keeps world coordinates; ``_apply_camera`` updates view limits
-        # and ``view_init`` to match the camera per frame (supports follow / orbit).
+        # 3D matplotlib keeps world coordinates; limits and ``view_init`` come from the
+        # camera once at ``open_scene``, then the interactive UI owns the viewpoint.
         if self.canvas.is_3d:
             draw_transforms = transforms
         else:
@@ -438,7 +437,11 @@ class MatplotlibRenderer(AnimationRenderer):
             draw_transforms = [W @ T for T in transforms]
         for prim, T in zip(primitives, draw_transforms):
             self.canvas.draw_primitive(prim, T)
-        self._apply_camera(self.ax, camera, self.canvas.is_3d)
+        # 2D: refresh orthographic limits and axis labels from *camera* each frame.
+        # 3D: *camera* was applied once in ``open_scene``; keep mpl toolbars / mouse
+        # orbit from being reset every frame.
+        if not self.canvas.is_3d:
+            self._apply_camera(self.ax, camera, False)
         self.ax.set_title(f"Time = {t:.2f} s", fontsize=FONT_SIZE)
 
     def present(self, *, block: bool, interval_s: float | None = None) -> None:
@@ -477,7 +480,8 @@ class MatplotlibRenderer(AnimationRenderer):
                 draw_transforms = [W @ T for T in frame["transforms"]]
             for prim, T in zip(primitives, draw_transforms):
                 canvas.draw_primitive(prim, T)
-            self._apply_camera(ax, camera, is_3d)
+            if not is_3d:
+                self._apply_camera(ax, camera, False)
             ax.set_title(f"Time = {frame['t']:.2f} s", fontsize=FONT_SIZE)
             return canvas.drawn_objects
 

--- a/minilink/graphical/renderers/meshcat_renderer.py
+++ b/minilink/graphical/renderers/meshcat_renderer.py
@@ -542,10 +542,8 @@ class MeshcatRenderer(AnimationRenderer):
         self.canvas.ensure_objects(primitives)
         for i, (prim, T) in enumerate(zip(primitives, transforms)):
             self.canvas.update_primitive(i, prim, T)
-        # Best-effort follow-camera: re-aim the orbit pivot at the look-at target
-        # so meshcat tracks moving systems. Eye distance / orientation set once at
-        # open_scene; users keep their interactive control via the browser.
-        _apply_meshcat_camera_target(self.vis, camera)
+        # Camera matrix is applied only in ``open_scene`` / native-animation setup
+        # so the browser orbit controls are not overwritten each frame.
 
     def present(self, *, block: bool, interval_s: float | None = None) -> None:
         if block:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to the standard camera matrix work: per-frame camera updates were resetting interactive orbit in Meshcat (moving `/Cameras/default` each frame) and matplotlib 3D (`view_init` + axis limits every frame), which felt broken when running animations from a normal console or browser.

## Changes

- **Meshcat** (`MeshcatRenderer.draw_frame`): no longer calls `_apply_meshcat_camera_target` each frame. Initial pivot and eye distance stay from `_apply_meshcat_camera` in `open_scene` / native-animation setup only.
- **Matplotlib 3D** (`MatplotlibRenderer.draw_frame` and `_build_animation`): `_apply_camera` runs each frame only for **2D**; 3D keeps the initial framing from `open_scene` / first frame of `FuncAnimation` so the mpl UI owns the viewpoint during playback.
- **DESIGN.md** §6: camera contract text updated (2D still uses per-frame projection; interactive 3D uses initial framing only).

## Tests

- `pytest tests/unittest/test_camera_transform.py`
- `pytest tests/unittest/test_visualization_optional.py` (skips where optional deps missing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fef4b162-36da-49fc-9cb4-ad5a75605170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fef4b162-36da-49fc-9cb4-ad5a75605170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

