### PR TITLE
Add pyro-to-minilink port gap todo (pyro 2.0 checklist)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,7 +20,7 @@ Maturity and priorities. Contracts: [DESIGN.md](DESIGN.md). Agent rules:
 | Graphical | 3 | Useful, but plotting/diagram APIs are still evolving. | Kinematic composition review before API freeze. |
 | Animation | 3 | Substantial work exists, but renderer, camera, and live-loop contracts may still change. | Same gate as Graphical. |
 | Dynamics catalog | 6 | Pyro plants ported, QA'd term-by-term; `DynamicBicycle` params thread fully. | `Manipulator` abstraction + catalog rebase (see review queue). |
-| Dynamics abstraction | 4 | `MechanicalSystem` complete; no shared `Manipulator` with task ports yet. | Add `q`/`dq` ports on `MechanicalSystem`; `Manipulator` with `p`/`pdot`. |
+| Dynamics abstraction | 5 | `MechanicalSystem` + joint ports `q`/`dq`; `Manipulator` in `manipulator.py` with `p`/`pdot`. | Rebase catalog arms; `JaxManipulator` if needed. |
 | Symbolic mechanics | 1 | One-shot AI-generated demos, not a validated subsystem. | Keep isolated until clear use cases justify review. |
 | Contact engine (`dynamics/engines/`) | 1 | Experimental; math not QA-validated. | Validation tests toward TRL 2. |
 | Analysis | 5 | Linearize, structural, equilibria, modal, selected-channel Bode. | Pole-zero, Nyquist, margins, `ss2tf`; reachability costs. |
@@ -129,8 +129,8 @@ Pre-decided homes ([DESIGN.md §3](DESIGN.md)), build order adjusted for pyro 2.
 ### 5.4 Dynamics abstraction
 
 - [x] `MechanicalSystem`, `JaxMechanicalSystem`, `StateSpaceSystem`, `GeneralizedMechanicalSystem`
-- [ ] `MechanicalSystem` ports `q`, `dq`
-- [ ] `Manipulator` base — `p`, `pdot`, `forward_kinematics`, `J`
+- [x] `MechanicalSystem` ports `q`, `dq` (`mechanical.py`)
+- [x] `Manipulator` base — `p`, `pdot`, `forward_kinematics`, `J` (`manipulator.py`)
 - [ ] Rebase `dynamics/catalog/manipulators/arms.py` on `Manipulator`
 - [ ] Optional `f_ext` input port for external end-effector forces
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,7 +20,7 @@ Maturity and priorities. Contracts: [DESIGN.md](DESIGN.md). Agent rules:
 | Graphical | 3 | Useful, but plotting/diagram APIs are still evolving. | Kinematic composition review before API freeze. |
 | Animation | 3 | Substantial work exists, but renderer, camera, and live-loop contracts may still change. | Same gate as Graphical. |
 | Dynamics catalog | 6 | Pyro plants ported, QA'd term-by-term; `DynamicBicycle` params thread fully. | `Manipulator` abstraction + catalog rebase (see review queue). |
-| Dynamics abstraction | 4 | `MechanicalSystem` complete; no shared `Manipulator` with task ports yet. | Add `q`/`dq` ports on `MechanicalSystem`; `Manipulator` with `r`/`dr`. |
+| Dynamics abstraction | 4 | `MechanicalSystem` complete; no shared `Manipulator` with task ports yet. | Add `q`/`dq` ports on `MechanicalSystem`; `Manipulator` with `p`/`pdot`. |
 | Symbolic mechanics | 1 | One-shot AI-generated demos, not a validated subsystem. | Keep isolated until clear use cases justify review. |
 | Contact engine (`dynamics/engines/`) | 1 | Experimental; math not QA-validated. | Validation tests toward TRL 2. |
 | Analysis | 5 | Linearize, structural, equilibria, modal, selected-channel Bode. | Pole-zero, Nyquist, margins, `ss2tf`; reachability costs. |
@@ -65,7 +65,7 @@ TRL definitions: [agent.md §8](agent.md#8-trl-lifecycle).
 done (routing, nonlinear, filters, `TrajectorySource`, PID, MIMO proportional).
 ~~`control/lqr.py`~~ done. Remaining:
 
-- `Manipulator` abstraction (`q`/`dq`/`r`/`dr` ports) — **unblocks robot control**
+- `Manipulator` abstraction (`q`/`dq`/`p`/`pdot` ports) — **unblocks robot control**
 - `control/computed_torque.py`, `control/sliding_mode.py`, `control/robotic.py`
 - Nested-diagram ergonomics; forced-input helpers; graphics kinematic composition
 
@@ -92,7 +92,8 @@ done (routing, nonlinear, filters, `TrajectorySource`, PID, MIMO proportional).
 - Dynamic bicycle module split.
 - Graphics/camera contract consolidation (`KinematicModel` delegate).
 - **`Manipulator` base class** — `MechanicalSystem` + `q`/`dq` ports;
-  `Manipulator` + `r`/`dr` + FK/Jacobian
+  `Manipulator` + `p`/`pdot` + `forward_kinematics` / `J(q)` (plant task outputs;
+  controller reference stays `r` per DESIGN)
   ([manipulator-abstraction.md](docs/plans/manipulator-abstraction.md)).
 - **DP/RRT return** — offline planning on continuous plants vs out-of-scope
   discrete framework (see gap doc §4).
@@ -129,7 +130,7 @@ Pre-decided homes ([DESIGN.md §3](DESIGN.md)), build order adjusted for pyro 2.
 
 - [x] `MechanicalSystem`, `JaxMechanicalSystem`, `StateSpaceSystem`, `GeneralizedMechanicalSystem`
 - [ ] `MechanicalSystem` ports `q`, `dq`
-- [ ] `Manipulator` base — `r`, `dr`, `forward_kinematic_effector`, `J`
+- [ ] `Manipulator` base — `p`, `pdot`, `forward_kinematics`, `J`
 - [ ] Rebase `dynamics/catalog/manipulators/arms.py` on `Manipulator`
 - [ ] Optional `f_ext` input port for external end-effector forces
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,6 +3,9 @@
 Maturity and priorities. Contracts: [DESIGN.md](DESIGN.md). Agent rules:
 [agent.md](agent.md).
 
+**Pyro 2.0 master gap checklist:**
+[docs/plans/pyro-port-gap-todo.md](docs/plans/pyro-port-gap-todo.md).
+
 ## 1. Maturity
 
 | Area | TRL | Rationale | Next |
@@ -11,14 +14,22 @@ Maturity and priorities. Contracts: [DESIGN.md](DESIGN.md). Agent rules:
 | Compile (`core/compile/`) | 4 | Integrated, but dynamic evaluator methods and exposed surface still need user review. | Review evaluator API, diagram parametric tier, and backend parity. |
 | Simulation | 7 | Mature workflow with stable API and solver/forcing coverage. | Keep behavior stable; treat `SimulationOptions` as ergonomic cleanup, not a redesign. |
 | Optimization | 5 | `MathematicalProgram` and `Optimizer` are integrated and useful, but backend details still need hardening. | Harden SciPy/Ipopt behavior and evaluator details before test-gated promotion. |
-| Planning/trajopt | 2 | Some user review happened, but much of the module remains AI one-shot prototype work. | Re-evaluate architecture/API before deeper integration. |
-| Graphical | 3 | Useful, but plotting/diagram APIs are still evolving. | Do not freeze public APIs until kinematic/visual hooks use composition (dynamics vs skin separation); re-evaluate after that review. |
-| Animation | 3 | Substantial work exists, but renderer, camera, and live-loop contracts may still change. | Same gate as Graphical: composition-based kinematic contract before TRL promotion or API freeze. |
-| Dynamics catalog | 6 | Pyro models ported, QA'd term-by-term against pyro, and covered by tests (see `docs/plans/catalog-migration-notes.md`); `DynamicBicycle` params now thread fully. | Review naming/details per module toward TRL 7. |
+| Planning/trajopt | 2 | Direct collocation / shooting exist; DP/RRT/polynomial generation not ported. | Architectural review for offline DP/RRT; traj generation. |
+| Planning/policy synthesis | 1 | Pyro DP/value iteration not ported; stubs removed. | Redesign under `planning/policy_synthesis/` (see pyro gap doc §4). |
+| Planning/search | 1 | Pyro RRT not ported; stubs removed. | Redesign under `planning/search/rrt.py`. |
+| Graphical | 3 | Useful, but plotting/diagram APIs are still evolving. | Kinematic composition review before API freeze. |
+| Animation | 3 | Substantial work exists, but renderer, camera, and live-loop contracts may still change. | Same gate as Graphical. |
+| Dynamics catalog | 6 | Pyro plants ported, QA'd term-by-term; `DynamicBicycle` params thread fully. | `Manipulator` abstraction + catalog rebase (see review queue). |
+| Dynamics abstraction | 4 | `MechanicalSystem` complete; no shared `Manipulator` with task ports yet. | Add `q`/`dq` ports on `MechanicalSystem`; `Manipulator` with `r`/`dr`. |
 | Symbolic mechanics | 1 | One-shot AI-generated demos, not a validated subsystem. | Keep isolated until clear use cases justify review. |
-| Contact engine (`dynamics/engines/`) | 1 | Moved out of quarantine by maintainer decision (June 2026); math not yet QA-validated. | Add validation tests (energy, analytic contact cases) toward TRL 2. |
-| Analysis | 5 | `linearize` (→ `LTISystem`, FD + JAX), `structural`, `equilibria`, `modal` (eigenmodes + animation), selected-channel Bode; demos in `examples/scripts/analysis/`. | Extend `frequency.py` with pole-zero, Nyquist, and margins. |
-| Control | 5 | `control/linear.py` (`ProportionalController` (SISO+MIMO)/`PDController`/`PIDController`/`LinearStateFeedbackController`), `control/lqr.py` (`lqr_gain`/`lqr`/`lqr_at_operating_point`), and `control/pid.py` (`FilteredPIDController` with anti-windup) integrated and tested. | Port computed-torque, sliding-mode, robotic controllers. |
+| Contact engine (`dynamics/engines/`) | 1 | Experimental; math not QA-validated. | Validation tests toward TRL 2. |
+| Analysis | 5 | Linearize, structural, equilibria, modal, selected-channel Bode. | Pole-zero, Nyquist, margins, `ss2tf`; reachability costs. |
+| Control | 5 | Linear, LQR, filtered PID done. | Computed torque, sliding mode, robotic controllers (blocked on `Manipulator`). |
+| Blocks | 5 | Routing, nonlinear, filters, sources, transfer function, 1-layer NN. | Multi-layer `MLP`, atomic layers (see neural-blocks plan). |
+| Estimation | 1 | Placeholder only. | Luenberger, Kalman, EKF. |
+| Identification | 2 | Parametric-tier prototype demo only. | `fitting.py` for physical + NN params. |
+| Interfaces | 1 | Placeholder only. | Gymnasium, Flax/Torch adapters. |
+| Pyro 2.0 overall | 3 | Catalog + core framework done; ~151/195 pyro demos not yet ported. | Phased port per [pyro-port-gap-todo.md](docs/plans/pyro-port-gap-todo.md) §5. |
 
 TRL definitions: [agent.md §8](agent.md#8-trl-lifecycle).
 
@@ -37,24 +48,41 @@ TRL definitions: [agent.md §8](agent.md#8-trl-lifecycle).
   generic blocks in top-level `blocks/`; generic control laws in
   `control/linear.py` and `control/pid.py`; `System` facades split into `core/facades.py`
   (API unchanged).
+- **Pyro catalog plants** — all EoM models ported and QA'd
+  ([catalog-migration-notes.md](docs/plans/catalog-migration-notes.md)).
+- **Pyro tool tranche 1** — blocks routing/nonlinear/filters/sources,
+  linear control + LQR, analysis linearize/structural/equilibria/modal/Bode
+  ([tool-migration-notes.md](docs/plans/tool-migration-notes.md)).
 
 ## 3. Priorities
 
 **P0** — Docs/contracts aligned with code; compiled vs reference path parity.
 
 **P1** — Dynamic evaluator API review; ~~diagram parametric evaluators (`f_p`,
-`h_p`)~~ done (nested `{sys_id: {…}}` params, `jacobian_f_params`; see
-DESIGN.md §4 Parameters and `examples/scripts/identification/demo_params_gradient.py`); diagram validation;
-top-level `minilink` exports; NLP hardening.
+`h_p`)~~ done; diagram validation; top-level `minilink` exports; NLP hardening.
 
-**P2** — ~~`analysis/` seed (linearization → matrices/`LTISystem`)~~ done (also ctrb/obsv,
-equilibria, modal, selected-channel Bode); remaining frequency tools pending. ~~`control/lqr.py` (design fn +
-state-feedback block)~~ done. ~~blocks round-out (Sum, Gain, Saturation; PID in
-`control/linear.py`)~~ done (routing, nonlinear, filters, `TrajectorySource`,
-PID, MIMO proportional). Remaining: nested-diagram ergonomics; forced-input
-helpers; swappable live graphics backends; refactor `System` visualization hooks
-(`get_kinematic_*`, camera) to delegate to composable kinematic models (pilot
-one catalog plant, e.g. pendulum) before calling `graphical/` TRL ≥ 4.
+**P2** — ~~Analysis seed~~ done (remaining frequency tools). ~~Blocks round-out~~
+done (routing, nonlinear, filters, `TrajectorySource`, PID, MIMO proportional).
+~~`control/lqr.py`~~ done. Remaining:
+
+- `Manipulator` abstraction (`q`/`dq`/`r`/`dr` ports) — **unblocks robot control**
+- `control/computed_torque.py`, `control/sliding_mode.py`, `control/robotic.py`
+- Nested-diagram ergonomics; forced-input helpers; graphics kinematic composition
+
+**P3** — Pyro 2.0 tool port (phases B–C in gap doc):
+
+- `planning/policy_synthesis/` (DP, lookup policy, grid discretizer)
+- `planning/search/rrt.py`
+- `planning/trajectory_generation/` (polynomial / min-snap)
+- `estimation/luenberger.py`, `estimation/kalman.py`
+- `identification/fitting.py`
+- `interfaces/gymnasium.py`
+
+**P4** — Demo parity + release polish (phases D–G in gap doc):
+
+- Port representative `demos_by_system/` closed-loop scripts per plant
+- Frequency completion; obstacle/Pacejka/stochastic layers (if approved)
+- Pyro migration guide in README; TRL 8 demos per tool band
 
 ## 4. Review queue (needs maintainer sign-off)
 
@@ -62,44 +90,116 @@ one catalog plant, e.g. pendulum) before calling `graphical/` TRL ≥ 4.
 - Diagram validation as separate `validate()` vs inline wiring.
 - Trajopt transcription internal consolidation.
 - Dynamic bicycle module split.
-- Graphics/camera contract consolidation, including kinematic composition
-  (optional `KinematicModel` delegate on `System`, fate of `get_dynamic_geometry`,
-  diagram aggregation unchanged) as a prerequisite for finalizing `graphical/`.
+- Graphics/camera contract consolidation (`KinematicModel` delegate).
+- **`Manipulator` base class** — `MechanicalSystem` + `q`/`dq` ports;
+  `Manipulator` + `r`/`dr` + FK/Jacobian
+  ([manipulator-abstraction.md](docs/plans/manipulator-abstraction.md)).
+- **DP/RRT return** — offline planning on continuous plants vs out-of-scope
+  discrete framework (see gap doc §4).
+- **Pyro game demos** — port via interactive animation or explicitly drop.
 
 ## 5. Future
 
-Pre-decided homes (bands and placement rules in [DESIGN.md §3](DESIGN.md)),
-in rough build order:
+Pre-decided homes ([DESIGN.md §3](DESIGN.md)), build order adjusted for pyro 2.0:
 
-1. **`analysis/`** — linearization (→ matrices/`LTISystem`), ctrb/obsv, equilibria,
-   modal (eigenmodes + animation), and selected-channel Bode done; still pending:
-   pole-zero, Nyquist, and margins.
-   Phase-plane math migrates here from `graphical/` when touched.
-2. **`control/`** — `lqr.py`, `linear.py`, and `control/pid.py`
-   (`FilteredPIDController`) done; still pending: `computed_torque.py`,
-   `sliding_mode.py`, `robotic.py` (impedance), `mpc.py` (uses `optimization/`),
-   `neural.py` (NN policies).
-3. **`blocks/`** — routing, nonlinear, filters, `TrajectorySource`, and
-   `neural.py` (MLP block with `params` = weights) done.
-4. **`estimation/`** — `luenberger.py`, `kalman.py`, later `ekf.py` (uses
-   `analysis/` linearization) and `recursive.py` (online parameter
-   estimators: RLS, adaptive laws). Offline fitting stays in
-   `identification/`.
-5. **`identification/`** — fit parametric systems to data; one verb for
-   physical params and network weights (`fitting.py`, first-order optimizers,
-   datasets). Depends on the parametric evaluator tier (P1).
-6. **`interfaces/`** — `gymnasium.py` (RL trains outside; policies return as
-   `control/` blocks), `torch.py`/`flax.py` model wrappers, cosimulation/FMI,
-   multibody import.
-7. **Quarantine graduation** — `symbolic/` as a dynamics-authoring tool.
-   (The JAX contact engine moved to `dynamics/engines/` in June 2026 —
-   still experimental; validation tests pending.)
+### 5.1 Analysis
 
-Out of scope by decision: discrete time (digital control, ZOH/delay blocks,
-RNNs, mixed-rate simulation) — minilink stays continuous-time only; see
-[DESIGN.md §3](DESIGN.md).
+- [x] Linearize (→ matrices/`LTISystem`), ctrb/obsv, equilibria, modal, Bode (selected channel)
+- [ ] Pole-zero, Nyquist, margins, `ss2tf`
+- [ ] Reachability / domain-check costs (for DP demos)
+- [ ] Phase-plane math migration from `graphical/` when touched
 
-Also: differentiable rollouts; hybrid/events; RRT and dynamic programming
-(removed as stubs — re-design before reintroducing, under `planning/search/`
-and `planning/policy_synthesis/`); phase-plane follow-ups (Plotly, 3D,
-compiled grid eval).
+### 5.2 Control
+
+- [x] `lqr.py`, `linear.py`, `pid.py` (`FilteredPIDController`)
+- [ ] `computed_torque.py`, `sliding_mode.py`
+- [ ] `robotic.py` — joint/effector PD/PID, kinematic, nullspace
+- [ ] `trajectory_lqr.py` — time-varying LQR along a reference
+- [ ] `mpc.py` (uses `optimization/`) — minilink extra, no pyro equivalent
+- [ ] `neural.py` — policy wrappers ([neural-blocks-collection.md](docs/plans/neural-blocks-collection.md))
+
+### 5.3 Blocks
+
+- [x] Routing, nonlinear, filters, `TrajectorySource`, `TransferFunction`, 1-layer `NeuralNetwork`
+- [ ] Multi-layer `MLP`, `Dense`/activation layers, `mlp_diagram` factory
+- [ ] `Switch` (deferred — selection semantics)
+- [ ] `RateLimiter`, `Hysteresis` (stateful nonlinear)
+
+### 5.4 Dynamics abstraction
+
+- [x] `MechanicalSystem`, `JaxMechanicalSystem`, `StateSpaceSystem`, `GeneralizedMechanicalSystem`
+- [ ] `MechanicalSystem` ports `q`, `dq`
+- [ ] `Manipulator` base — `r`, `dr`, `forward_kinematic_effector`, `J`
+- [ ] Rebase `dynamics/catalog/manipulators/arms.py` on `Manipulator`
+- [ ] Optional `f_ext` input port for external end-effector forces
+
+### 5.5 Planning
+
+- [x] Trajectory optimization (direct collocation, shooting, multiple shooting)
+- [ ] `trajectory_generation/` — polynomial / min-snap
+- [ ] `policy_synthesis/` — DP, lookup table controller, policy evaluator, grid discretizer
+- [ ] `search/rrt.py`
+- [ ] Trajectory post-filter (Butterworth `filtfilt`)
+
+### 5.6 Estimation and identification
+
+- [ ] `estimation/luenberger.py`, `kalman.py`, `ekf.py`, `recursive.py`
+- [ ] `identification/fitting.py` — one verb for physical params and NN weights
+
+### 5.7 Interfaces
+
+- [ ] `gymnasium.py` — diagram as RL env (train outside)
+- [ ] `flax.py`, `torch.py` — external model → `StaticSystem`
+- [ ] Cosimulation / FMI, multibody import
+
+### 5.8 Catalog capability gaps (not EoM)
+
+- [ ] Obstacle collision layer (replace pyro `*withObstacles` plants)
+- [ ] `Pacejka` tire model
+- [ ] Stochastic forcing / `NoiseSignal` blocks
+
+### 5.9 Quarantine graduation
+
+- [ ] `symbolic/` as dynamics-authoring tool
+- [ ] Contact engine validation (`dynamics/engines/`)
+
+### 5.10 Out of scope (by decision)
+
+Discrete time (ZOH/delay, digital control), RNNs, mixed-rate simulation,
+differentiable-rollout library, hybrid/events — see [DESIGN.md §3](DESIGN.md).
+Pygame game framework (`sys2game`) — no first-class port unless reversed.
+
+## 6. Pyro 2.0 port status
+
+Snapshot vs [SherbyRobotics/pyro](https://github.com/SherbyRobotics/pyro) (June 2026).
+
+| Bucket | Pyro | Minilink | Gap |
+| --- | ---: | ---: | ---: |
+| Catalog plants | 40+ | 40+ | **0** (QA complete) |
+| Library modules | 38 | ~25 equivalent | **~10 tools** (control nonlinear/robot, DP, RRT, traj gen, estimation, interfaces) |
+| Example scripts | 195 | 44 | **~151** |
+| Course notebooks | 3 | 7 (new topics) | different mix |
+
+### Port phases (from gap doc)
+
+| Phase | Focus | Unblocks |
+| --- | --- | --- |
+| **A** | `Manipulator` abstraction + computed torque + sliding mode + `robotic.py` | ~50 robot/pendulum demos |
+| **B** | DP/RRT redesign + polynomial traj gen + trajectory LQR | ~50 planning demos |
+| **C** | Estimation + identification + Gym interface | LQG + RL demos |
+| **D** | Frequency completion + planning cost variants | analysis + DP reachability |
+| **E** | Obstacles, Pacejka, stochastic | specialized catalog |
+| **F** | Demo audit (`demos_by_system/`, courses, projects) | pyro parity visibility |
+| **G** | Export policy, compile review, migration guide, TRL 8 | release criteria |
+
+### Definition of done (pyro 2.0)
+
+1. Every **in-scope** pyro library module has a minilink home or documented replacement.
+2. Every **in-scope** pyro plant folder has ≥1 representative closed-loop demo.
+3. DP/RRT approved and landed **or** explicitly dropped with alternatives documented.
+4. Robot control suite (computed torque, sliding mode, robotic) at TRL ≥ 6.
+5. `identification/fitting.py` covers the params-gradient workflow.
+6. README includes a pyro → minilink API migration guide.
+
+Full per-module and per-demo checklists:
+[docs/plans/pyro-port-gap-todo.md](docs/plans/pyro-port-gap-todo.md).

--- a/docs/plans/manipulator-abstraction.md
+++ b/docs/plans/manipulator-abstraction.md
@@ -6,162 +6,266 @@ Context: porting pyro `Manipulator` and `control/robotcontrollers.py` requires a
 shared robot base in minilink. Today catalog arms subclass `MechanicalSystem`
 directly and duplicate FK/Jacobian methods without exposing them as diagram ports.
 
-## Goal
+Design goal: **notation should read like a robotics/controls textbook** in both
+the port wiring diagram and the method names — while respecting minilink's
+framework-wide control convention (`r` = reference, `y` = measurement, `u` =
+actuator command).
 
-A controls reader should wire
+## Textbook notation map
 
-    controller.r  ──┐
-    plant.q    ─────┼──► JointPD / ComputedTorque / EndEffectorPD
-    plant.dq   ─────┘
+Standard manipulator notation (e.g. Spong/Hutchinson, Siciliano):
 
-without `Demux` on a stacked `y` vector. Cartesian controllers should wire
-`plant.r` and `plant.dr` directly.
+| Math | Meaning | Minilink role |
+| --- | --- | --- |
+| `q` | generalized coordinates (joint positions) | plant output port `q` |
+| `q̇` | generalized velocities | plant output port `dq` |
+| `x = [q; q̇]` | mechanical state | plant state / ports `x`, `y` |
+| `τ` | applied joint torques | plant input port `u` (documented as `τ` for arms) |
+| `H(q)`, `C(q,q̇)`, `g(q)` | inertia, Coriolis, gravity | methods on `MechanicalSystem` |
+| `p = f(q)` | forward kinematics (task position) | plant output port `p` |
+| `ṗ = J(q) q̇` | differential kinematics | plant output port `pdot` |
+| `J(q)` | manipulator Jacobian `∂p/∂q` | method `J(q, params)` |
+| `p_d`, `ṗ_d` | desired task position / velocity | **controller** input `r` (reference), not a plant port |
+| `f_ext` | external wrench at end-effector | future plant **input** port (phase 2) |
+
+### Why not pyro's `r` / `dr` on the plant?
+
+Minilink reserves **`r` for the reference input on controllers**
+([DESIGN.md §4](../../DESIGN.md)). A plant output named `r` would collide in
+every diagram:
+
+```text
+  ref.r  ──► controller.r     (desired p_d)   ✓ textbook + framework
+  plant.r ──► controller.y    (measured p)    ✗ reads as two “references”
+```
+
+**Plant task-space outputs are `p` and `pdot`** (position and its time derivative).
+The desired task trajectory connects to the controller's **`r`** port; the
+measured task state connects to **`y`** — the same pattern as joint-space PD on
+`[q, dq]`.
+
+### Why `dq` and `pdot` (not `qdot` / `v`)?
+
+| Candidate | Verdict |
+| --- | --- |
+| `dq` | **Joint port.** Matches `q̇` in code; already used in `control/linear.py` docstrings (`[q, dq]`). |
+| `qdot` | Readable but breaks the two-letter port pattern (`q`, `dq`, `p`, `pdot`). |
+| `v` on a port | **Rejected** — ambiguous (joint rate vs task velocity vs state segment). |
+| `pdot` | **Task port.** Parallel to `dq`; reads as `ṗ` without overloading `v`. |
+| `p` | **Task port.** Standard task-space position; avoids overloading framework state `x`. |
+
+Internal math may still use short locals `q`, `dq`, `p`, `pdot`, `J`, `tau`
+after unpacking `x`, `u`, `params` ([agent.md](../../agent.md) textbook style).
+
+## Goal (wiring picture)
+
+Joint-space PD:
+
+```text
+  ref.r ─────────────► controller.r
+  plant.q  ──┐
+  plant.dq ──┴─ Mux ─► controller.y
+  controller.u ────────► plant.u
+```
+
+End-effector PD (operational space):
+
+```text
+  ref.r ─────────────► controller.r          (desired p_d; rate part via metadata / Mux)
+  plant.p ──┐
+  plant.pdot ┴─ Mux ──► controller.y         (measured [p, ṗ])
+  controller.u ────────► plant.u             (τ)
+```
+
+No `Demux` on stacked `y` for new robot demos.
 
 ## Proposed hierarchy
 
-```
+```text
 DynamicSystem
-    └── MechanicalSystem          # any second-order mechanism in q
-            └── Manipulator       # serial arms with an end-effector frame
+    └── MechanicalSystem          #  H(q) q̈ + C(q,q̇) q̇ + g(q) = τ
+            └── Manipulator       #  +  p = f(q),  ṗ = J(q) q̇
 ```
 
-Catalog plants (`OneLinkManipulator`, `TwoLinkManipulator`, …) subclass
-`Manipulator`, not `MechanicalSystem` directly.
+Catalog arms (`OneLinkManipulator`, …) subclass `Manipulator`.
 
 Home: `minilink/dynamics/abstraction/manipulator.py`.
 
 ## Port contract
 
-### `MechanicalSystem` — add joint-space outputs
+### Framework ports (unchanged)
 
-Today: primary `y = [q; v]` (same as `x` when `expose_state=True`), plus
-auxiliary port `x`.
+| Port | Role |
+| --- | --- |
+| `u` | actuator command; for manipulators document as **joint torque `τ`** |
+| `y` | primary output (`System.p`); stays **`y = x = [q; dq]`** for backward compatibility |
+| `x` | full state (already exposed via `expose_state=True`) |
 
-**Add** (non-breaking — keep `y` and `x`):
+### `MechanicalSystem` — joint-space outputs (new)
 
-| Port | Dim | Compute | Notes |
+| Port | Dim | Compute | Textbook |
 | --- | ---: | --- | --- |
-| `q` | `dof` | `x2q(x)[0]` | generalized positions |
-| `dq` | `dof` | `x2q(x)[1]` | generalized velocities (`v` in math) |
+| `q` | `dof` | `x2q(x)[0]` | `q` |
+| `dq` | `dof` | `x2q(x)[1]` | `q̇` |
 
-Port labels/units inherit from the first/second half of `state.labels` /
-`state.units`. Dependencies: `()` — no feedthrough.
+Dependencies: `()` (no feedthrough). Labels/units from the first / second half of
+`state.labels` and `state.units`.
 
-Rationale:
+### `Manipulator` — task-space outputs (new)
 
-- Matches control naming (`q`, `dq`) used in pyro robot controllers.
-- `y` remains the primary output (`System.p` unchanged) for backward compatibility.
-- `x` stays for state-feedback blocks that want the full vector.
-- Controllers that need only angles or rates connect to named ports.
-
-### `Manipulator` — add task-space outputs
-
-| Port | Dim | Compute | Notes |
+| Port | Dim | Compute | Textbook |
 | --- | ---: | --- | --- |
-| `r` | `e` | `forward_kinematic_effector(q, params)` | end-effector pose/coords |
-| `dr` | `e` | `J(q, params) @ dq` | end-effector velocity |
+| `p` | `task_dim` | `forward_kinematics(q, params)` | `p = f(q)` |
+| `pdot` | `task_dim` | `J(q, params) @ dq` | `ṗ = J(q) q̇` |
 
-Constructor: `Manipulator(dof, actuators=None, effector_dim=2)`.
+Constructor: `Manipulator(dof, actuators=None, task_dim=2)`.
 
-Subclasses **must** override:
+Attribute `task_dim` replaces pyro's `e` / catalog's `effector_dim` in new code
+(catalog migration may keep a property alias during transition).
+
+## Method contract (textbook names)
+
+### On `MechanicalSystem` (existing + port helpers)
+
+| Method | Returns | Textbook |
+| --- | --- | --- |
+| `H(q, params)` | `(dof, dof)` | inertia matrix |
+| `C(q, dq, params)` | `(dof, dof)` | Coriolis matrix |
+| `g(q, params)` | `(dof,)` | gravity vector |
+| `B(q, params)` | `(dof, m)` | actuator map |
+| `d(q, dq, u, t, params)` | `(dof,)` | damping / dissipation |
+| `generalized_force(...)` | `(dof,)` | RHS force; default `B(q) @ u` → `τ` |
+| `forward_dynamics(q, dq, u, ...)` | `ddq` | `q̈` from `τ` |
+| `inverse_dynamics(q, dq, ddq, ...)` | `tau` | `τ` from `q̈` |
+| `x2q(x)` | `[q, dq]` | split `x = [q; q̇]` |
+| `q2x(q, dq)` | `x` | stack state |
+
+Port wiring helpers (thin; not part of the textbook EoM):
+
+| Method | Port |
+| --- | --- |
+| `h_q(x, u, t, params)` | `q` |
+| `h_dq(x, u, t, params)` | `dq` |
+
+Prefer **`h_q` / `h_dq`** over `compute_q` so port functions read as output maps
+`h_port` while `f` / `H` / `C` stay the dynamics vocabulary.
+
+### On `Manipulator` (subclass hooks)
+
+| Method | Returns | Textbook |
+| --- | --- | --- |
+| `forward_kinematics(q, params)` | `(task_dim,)` | `p = f(q)` |
+| `J(q, params)` | `(task_dim, dof)` | `J(q) = ∂p/∂q` |
+
+Default implementations return zeros (safe for abstract tests / JAX trace).
+
+Optional inline helper (not a separate port):
 
 ```python
-def forward_kinematic_effector(self, q, params=None):
-    ...
-
-def J(self, q, params=None):
-    ...  # shape (effector_dim, dof)
+# ṗ = J(q) q̇  — used by h_pdot and by controllers
+pdot = J @ dq
 ```
 
-Default implementations return zeros (traceable, safe for abstract testing).
+Port wiring:
 
-Optional helper (not a port):
+| Method | Port |
+| --- | --- |
+| `h_p(x, u, t, params)` | `p` |
+| `h_pdot(x, u, t, params)` | `pdot` |
 
-```python
-def forward_differential_kinematic_effector(self, q, dq, params=None):
-    return self.J(q, params) @ dq
-```
+### Pyro → minilink rename (catalog migration)
+
+| Pyro / catalog today | Proposed |
+| --- | --- |
+| `forward_kinematic_effector(q)` | `forward_kinematics(q, params)` |
+| `forward_differential_kinematic_effector(q, dq)` | inline `J(q) @ dq` or `task_velocity(q, dq, params)` if a named helper helps |
+| `effector_dim` | `task_dim` |
+| `e` (pyro) | `task_dim` |
+
+Keep **`J`** as the method name — it *is* the textbook symbol.
 
 ## Math hooks (unchanged)
 
-`MechanicalSystem` keeps `H`, `C`, `B`, `g`, `d`, `generalized_force`,
-`forward_dynamics`, `inverse_dynamics`. `Manipulator` does not alter `f`/`h`.
+`Manipulator` does **not** override `f` / `H` / `C` / `g`. It only adds
+kinematic outputs. Dynamics remain:
 
-Port compute paths call the same FK/Jacobian used by graphics and future
-`control/robotic.py` blocks — **one definition, three consumers** (ports,
-animation, control laws).
-
-## Relation to pyro
-
-Pyro `Manipulator` stores `e` (effector dim), documents `r = f(q)`,
-`dr = J(q) dq`, and expects subclasses to implement FK + `J`. Minilink mirrors
-that math but expresses outputs as **explicit ports** instead of methods only.
-
-Pyro `RobotController.x2q(y)` assumed `y` was stacked joint space. Minilink
-controllers should prefer `get_port_values_from_u` / diagram connections to
-`plant.q` and `plant.dq`, or read ports from compiled internal signals.
-
-## Implementation sketch
-
-In `MechanicalSystem.__init__` after port setup:
-
-```python
-self.add_output_port("q", dim=dof, function=self.compute_q, dependencies=())
-self.add_output_port("dq", dim=dof, function=self.compute_dq, dependencies=())
+```text
+H(q) q̈ + C(q, q̇) q̇ + g(q) + d(q, q̇, u, t) = B(q) u
 ```
 
+One `forward_kinematics` / `J` definition serves **ports**, **animation**, and
+future **`control/robotic.py`** blocks.
+
+## Relation to future controllers
+
+Naming alignment for `control/robotic.py` (planned):
+
+| Controller | Plant inputs wired | Law (textbook) |
+| --- | --- | --- |
+| Joint PD / PID | `y` ← Mux(`q`, `dq`) | `τ = K_p (q_d - q) + K_d (q̇_d - q̇)` |
+| Computed torque | `q`, `dq` (+ ref trajectory) | `τ = H(q) v + C(q,q̇)q̇ + g(q)` |
+| End-effector PD | `y` ← Mux(`p`, `pdot`) | `τ = J(q)^T ( K_p (p_d - p) + K_d (ṗ_d - ṗ) )` |
+| Kinematic (resolved rate) | `q`, `p` | `q̇ = J(q)^+ ṗ_d` |
+
+Controller ports stay **`r`, `y`, `u`** per DESIGN. Task-space **desired**
+trajectories use `r`; **measured** task state uses `y` fed from `plant.p` /
+`plant.pdot`.
+
+## Implementation sketch (for later — not in this PR)
+
 ```python
-def compute_q(self, x, u, t=0, params=None):
-    q, _ = self.x2q(x)
-    return q
+# MechanicalSystem.__init__ (after existing ports)
+self.add_output_port("q", dim=dof, function=self.h_q, dependencies=())
+self.add_output_port("dq", dim=dof, function=self.h_dq, dependencies=())
 
-def compute_dq(self, x, u, t=0, params=None):
-    _, dq = self.x2q(x)
-    return dq
-```
-
-In `Manipulator.__init__`:
-
-```python
+# Manipulator.__init__
 super().__init__(dof=dof, actuators=actuators)
-self.effector_dim = int(effector_dim)
-self.add_output_port("r", dim=self.effector_dim, function=self.compute_r, dependencies=())
-self.add_output_port("dr", dim=self.effector_dim, function=self.compute_dr, dependencies=())
+self.task_dim = int(task_dim)
+self.add_output_port("p", dim=self.task_dim, function=self.h_p, dependencies=())
+self.add_output_port("pdot", dim=self.task_dim, function=self.h_pdot, dependencies=())
 ```
 
-## Catalog migration
+```python
+def h_p(self, x, u, t=0, params=None):
+    q, dq = self.x2q(x)
+    return self.forward_kinematics(q, params)
 
-1. Add `Manipulator` base with ports.
-2. Change `OneLinkManipulator` … `FiveLinkPlanarManipulator` to subclass
-   `Manipulator`; move shared FK/Jacobian to the subclass (already there).
-3. `SpeedControlledManipulator` — separate kinematic-only plant; may subclass
-   a lighter `KinematicManipulator` (positions only, no `H`) **or** stay as
-   `DynamicSystem` until needed.
-4. Update tests: port dimensions, FK/Jacobian match `compute_r`/`compute_dr`.
-5. Demos for joint PD and effector PD wire `plant.q` / `plant.r` explicitly.
+def h_pdot(self, x, u, t=0, params=None):
+    q, dq = self.x2q(x)
+    J = self.J(q, params)
+    return J @ dq
+```
+
+## Catalog migration (later)
+
+1. Add `Manipulator` in `dynamics/abstraction/`.
+2. Rebase `OneLinkManipulator` … `FiveLinkPlanarManipulator` on `Manipulator`.
+3. Rename `forward_kinematic_effector` → `forward_kinematics` (clean break;
+   pre-1.0 no-alias rule).
+4. `SpeedControlledManipulator` — kinematic-only plant; defer or introduce
+   `KinematicChain` (positions only, no `H`) when a demo needs it.
+5. Tests: `h_p` / `h_pdot` match analytic FK and `J @ dq`.
+6. Demo: `TwoLinkManipulator` + joint PD with `plant.q` / `plant.dq` wiring.
 
 ## Open questions
 
-1. **Port name `dq` vs `v`?** Proposal: `dq` on ports (control language),
-   `v` stays as the local in `x2q` and EoM text.
-2. **Effector `r` for 3D arms:** `e=3` position only first; orientation as
-   Euler/quaternion is a follow-up (`effector_dim` or separate `R` port?).
-3. **External forces `f_ext`:** pyro documents `J^T f_ext` on the RHS.
-   Implement via optional input port `f_ext` on `Manipulator` later, not in v1.
-4. **Breaking change?** Keeping `y=[q;dq]` means no break; deprecate using
-   `y` for robot control wiring in new demos only.
-5. **`JaxManipulator` twin?** Mirror `JaxMechanicalSystem` pattern if catalog
-   gains JAX arm variants.
+1. **3D orientation in `p`:** v1 = position components only (`task_dim=3`);
+   orientation as separate ports (`R`, `omega`) or augmented `p` later?
+2. **`f_ext` input port:** external wrench; adds `J(q)^T f_ext` to the RHS —
+   phase 2, not v1.
+3. **`JaxManipulator`:** mirror `JaxMechanicalSystem` when JAX arms are needed.
+4. **Stacked convenience port:** optional `task` port = Mux(`p`, `pdot`) factory
+   for controllers that want one `y` — diagram helper only, not on the plant?
 
 ## Enables (blocked today)
 
-- `control/computed_torque.py` — needs `inverse_dynamics` + `q`, `dq`
-- `control/robotic.py` — `JointPD`, `EndEffectorPD`, kinematic controllers
-- `control/sliding_mode.py` — same access pattern
-- Obstacle-aware arms — collision on `r`, not a separate plant subclass
+- `control/computed_torque.py` — `inverse_dynamics`, ports `q`, `dq`
+- `control/robotic.py` — joint / operational-space laws
+- `control/sliding_mode.py`
+- Obstacle checks on `p` instead of per-plant `*withObstacles` subclasses
 
-## Smallest slice
+## Smallest implementation slice (when approved)
 
-1. `MechanicalSystem` gains `q`/`dq` ports + compute helpers.
-2. `Manipulator` base with `r`/`dr` ports; migrate `OneLinkManipulator` only.
-3. One demo: `TwoLinkManipulator` + joint PD using port wiring.
+1. `MechanicalSystem`: ports `q`, `dq` + `h_q`, `h_dq`.
+2. `Manipulator`: ports `p`, `pdot` + `forward_kinematics`, `J`, `h_p`, `h_pdot`.
+3. Migrate `OneLinkManipulator` only; one joint-PD demo.

--- a/docs/plans/manipulator-abstraction.md
+++ b/docs/plans/manipulator-abstraction.md
@@ -1,0 +1,167 @@
+# Manipulator Base Abstraction — Proposal
+
+Status: **proposal for architectural review** (`TODO: User Architectural Review`).
+
+Context: porting pyro `Manipulator` and `control/robotcontrollers.py` requires a
+shared robot base in minilink. Today catalog arms subclass `MechanicalSystem`
+directly and duplicate FK/Jacobian methods without exposing them as diagram ports.
+
+## Goal
+
+A controls reader should wire
+
+    controller.r  ──┐
+    plant.q    ─────┼──► JointPD / ComputedTorque / EndEffectorPD
+    plant.dq   ─────┘
+
+without `Demux` on a stacked `y` vector. Cartesian controllers should wire
+`plant.r` and `plant.dr` directly.
+
+## Proposed hierarchy
+
+```
+DynamicSystem
+    └── MechanicalSystem          # any second-order mechanism in q
+            └── Manipulator       # serial arms with an end-effector frame
+```
+
+Catalog plants (`OneLinkManipulator`, `TwoLinkManipulator`, …) subclass
+`Manipulator`, not `MechanicalSystem` directly.
+
+Home: `minilink/dynamics/abstraction/manipulator.py`.
+
+## Port contract
+
+### `MechanicalSystem` — add joint-space outputs
+
+Today: primary `y = [q; v]` (same as `x` when `expose_state=True`), plus
+auxiliary port `x`.
+
+**Add** (non-breaking — keep `y` and `x`):
+
+| Port | Dim | Compute | Notes |
+| --- | ---: | --- | --- |
+| `q` | `dof` | `x2q(x)[0]` | generalized positions |
+| `dq` | `dof` | `x2q(x)[1]` | generalized velocities (`v` in math) |
+
+Port labels/units inherit from the first/second half of `state.labels` /
+`state.units`. Dependencies: `()` — no feedthrough.
+
+Rationale:
+
+- Matches control naming (`q`, `dq`) used in pyro robot controllers.
+- `y` remains the primary output (`System.p` unchanged) for backward compatibility.
+- `x` stays for state-feedback blocks that want the full vector.
+- Controllers that need only angles or rates connect to named ports.
+
+### `Manipulator` — add task-space outputs
+
+| Port | Dim | Compute | Notes |
+| --- | ---: | --- | --- |
+| `r` | `e` | `forward_kinematic_effector(q, params)` | end-effector pose/coords |
+| `dr` | `e` | `J(q, params) @ dq` | end-effector velocity |
+
+Constructor: `Manipulator(dof, actuators=None, effector_dim=2)`.
+
+Subclasses **must** override:
+
+```python
+def forward_kinematic_effector(self, q, params=None):
+    ...
+
+def J(self, q, params=None):
+    ...  # shape (effector_dim, dof)
+```
+
+Default implementations return zeros (traceable, safe for abstract testing).
+
+Optional helper (not a port):
+
+```python
+def forward_differential_kinematic_effector(self, q, dq, params=None):
+    return self.J(q, params) @ dq
+```
+
+## Math hooks (unchanged)
+
+`MechanicalSystem` keeps `H`, `C`, `B`, `g`, `d`, `generalized_force`,
+`forward_dynamics`, `inverse_dynamics`. `Manipulator` does not alter `f`/`h`.
+
+Port compute paths call the same FK/Jacobian used by graphics and future
+`control/robotic.py` blocks — **one definition, three consumers** (ports,
+animation, control laws).
+
+## Relation to pyro
+
+Pyro `Manipulator` stores `e` (effector dim), documents `r = f(q)`,
+`dr = J(q) dq`, and expects subclasses to implement FK + `J`. Minilink mirrors
+that math but expresses outputs as **explicit ports** instead of methods only.
+
+Pyro `RobotController.x2q(y)` assumed `y` was stacked joint space. Minilink
+controllers should prefer `get_port_values_from_u` / diagram connections to
+`plant.q` and `plant.dq`, or read ports from compiled internal signals.
+
+## Implementation sketch
+
+In `MechanicalSystem.__init__` after port setup:
+
+```python
+self.add_output_port("q", dim=dof, function=self.compute_q, dependencies=())
+self.add_output_port("dq", dim=dof, function=self.compute_dq, dependencies=())
+```
+
+```python
+def compute_q(self, x, u, t=0, params=None):
+    q, _ = self.x2q(x)
+    return q
+
+def compute_dq(self, x, u, t=0, params=None):
+    _, dq = self.x2q(x)
+    return dq
+```
+
+In `Manipulator.__init__`:
+
+```python
+super().__init__(dof=dof, actuators=actuators)
+self.effector_dim = int(effector_dim)
+self.add_output_port("r", dim=self.effector_dim, function=self.compute_r, dependencies=())
+self.add_output_port("dr", dim=self.effector_dim, function=self.compute_dr, dependencies=())
+```
+
+## Catalog migration
+
+1. Add `Manipulator` base with ports.
+2. Change `OneLinkManipulator` … `FiveLinkPlanarManipulator` to subclass
+   `Manipulator`; move shared FK/Jacobian to the subclass (already there).
+3. `SpeedControlledManipulator` — separate kinematic-only plant; may subclass
+   a lighter `KinematicManipulator` (positions only, no `H`) **or** stay as
+   `DynamicSystem` until needed.
+4. Update tests: port dimensions, FK/Jacobian match `compute_r`/`compute_dr`.
+5. Demos for joint PD and effector PD wire `plant.q` / `plant.r` explicitly.
+
+## Open questions
+
+1. **Port name `dq` vs `v`?** Proposal: `dq` on ports (control language),
+   `v` stays as the local in `x2q` and EoM text.
+2. **Effector `r` for 3D arms:** `e=3` position only first; orientation as
+   Euler/quaternion is a follow-up (`effector_dim` or separate `R` port?).
+3. **External forces `f_ext`:** pyro documents `J^T f_ext` on the RHS.
+   Implement via optional input port `f_ext` on `Manipulator` later, not in v1.
+4. **Breaking change?** Keeping `y=[q;dq]` means no break; deprecate using
+   `y` for robot control wiring in new demos only.
+5. **`JaxManipulator` twin?** Mirror `JaxMechanicalSystem` pattern if catalog
+   gains JAX arm variants.
+
+## Enables (blocked today)
+
+- `control/computed_torque.py` — needs `inverse_dynamics` + `q`, `dq`
+- `control/robotic.py` — `JointPD`, `EndEffectorPD`, kinematic controllers
+- `control/sliding_mode.py` — same access pattern
+- Obstacle-aware arms — collision on `r`, not a separate plant subclass
+
+## Smallest slice
+
+1. `MechanicalSystem` gains `q`/`dq` ports + compute helpers.
+2. `Manipulator` base with `r`/`dr` ports; migrate `OneLinkManipulator` only.
+3. One demo: `TwoLinkManipulator` + joint PD using port wiring.

--- a/docs/plans/manipulator-abstraction.md
+++ b/docs/plans/manipulator-abstraction.md
@@ -89,7 +89,19 @@ DynamicSystem
 
 Catalog arms (`OneLinkManipulator`, …) subclass `Manipulator`.
 
-Home: `minilink/dynamics/abstraction/manipulator.py`.
+## File layout
+
+Abstractions are split by role — do **not** put :class:`Manipulator` in
+``mechanical.py``.
+
+| File | Class | Responsibility |
+| --- | --- | --- |
+| `dynamics/abstraction/mechanical.py` | `MechanicalSystem`, `JaxMechanicalSystem` | `H`, `C`, `g`, `f`; joint ports `q`, `dq` |
+| `dynamics/abstraction/manipulator.py` | `Manipulator` | `forward_kinematics`, `J`; task ports `p`, `pdot` |
+
+Import :class:`Manipulator` from ``minilink.dynamics.abstraction.manipulator``.
+Catalog arms import both bases from their defining modules (no barrel re-export
+in ``__init__.py`` until API freeze).
 
 ## Port contract
 
@@ -211,21 +223,15 @@ Controller ports stay **`r`, `y`, `u`** per DESIGN. Task-space **desired**
 trajectories use `r`; **measured** task state uses `y` fed from `plant.p` /
 `plant.pdot`.
 
-## Implementation sketch (for later — not in this PR)
+## Implementation status
 
-```python
-# MechanicalSystem.__init__ (after existing ports)
-self.add_output_port("q", dim=dof, function=self.h_q, dependencies=())
-self.add_output_port("dq", dim=dof, function=self.h_dq, dependencies=())
+- [x] `MechanicalSystem`: ports `q`, `dq` + `h_q`, `h_dq` in `mechanical.py`
+- [x] `Manipulator`: ports `p`, `pdot` + kinematic hooks in `manipulator.py`
+- [ ] Rebase catalog `arms.py` on `Manipulator`
+- [ ] `JaxManipulator` twin (when needed)
+- [ ] Joint-PD demo with explicit port wiring
 
-# Manipulator.__init__
-super().__init__(dof=dof, actuators=actuators)
-self.task_dim = int(task_dim)
-self.add_output_port("p", dim=self.task_dim, function=self.h_p, dependencies=())
-self.add_output_port("pdot", dim=self.task_dim, function=self.h_pdot, dependencies=())
-```
-
-```python
+### Reference (`manipulator.py`)
 def h_p(self, x, u, t=0, params=None):
     q, dq = self.x2q(x)
     return self.forward_kinematics(q, params)
@@ -238,14 +244,14 @@ def h_pdot(self, x, u, t=0, params=None):
 
 ## Catalog migration (later)
 
-1. Add `Manipulator` in `dynamics/abstraction/`.
-2. Rebase `OneLinkManipulator` … `FiveLinkPlanarManipulator` on `Manipulator`.
-3. Rename `forward_kinematic_effector` → `forward_kinematics` (clean break;
+1. Rebase `OneLinkManipulator` … `FiveLinkPlanarManipulator` on `Manipulator`
+   (import from `dynamics/abstraction/manipulator.py`).
+2. Rename `forward_kinematic_effector` → `forward_kinematics` (clean break;
    pre-1.0 no-alias rule).
-4. `SpeedControlledManipulator` — kinematic-only plant; defer or introduce
+3. `SpeedControlledManipulator` — kinematic-only plant; defer or introduce
    `KinematicChain` (positions only, no `H`) when a demo needs it.
-5. Tests: `h_p` / `h_pdot` match analytic FK and `J @ dq`.
-6. Demo: `TwoLinkManipulator` + joint PD with `plant.q` / `plant.dq` wiring.
+4. Catalog tests: FK/`h_p`/`h_pdot` parity on concrete arms.
+5. Demo: `TwoLinkManipulator` + joint PD with `plant.q` / `plant.dq` wiring.
 
 ## Open questions
 
@@ -264,8 +270,6 @@ def h_pdot(self, x, u, t=0, params=None):
 - `control/sliding_mode.py`
 - Obstacle checks on `p` instead of per-plant `*withObstacles` subclasses
 
-## Smallest implementation slice (when approved)
+## Smallest remaining slice (when approved)
 
-1. `MechanicalSystem`: ports `q`, `dq` + `h_q`, `h_dq`.
-2. `Manipulator`: ports `p`, `pdot` + `forward_kinematics`, `J`, `h_p`, `h_pdot`.
-3. Migrate `OneLinkManipulator` only; one joint-PD demo.
+1. Migrate `OneLinkManipulator` only; one joint-PD demo.

--- a/docs/plans/pyro-port-gap-todo.md
+++ b/docs/plans/pyro-port-gap-todo.md
@@ -1,0 +1,416 @@
+# Pyro → Minilink Port Gap Todo (Pyro 2.0)
+
+Working checklist for finalizing minilink as the successor to
+[SherbyRobotics/pyro](https://github.com/SherbyRobotics/pyro). Status snapshot:
+**June 2026**.
+
+Companion docs:
+
+- [catalog-migration-notes.md](catalog-migration-notes.md) — plants (done)
+- [tool-migration-notes.md](tool-migration-notes.md) — first tool tranche (partial)
+- [neural-blocks-collection.md](neural-blocks-collection.md) — NN blocks (planned)
+
+## Headline counts
+
+| Bucket | Pyro | Minilink today | Gap |
+| --- | ---: | ---: | ---: |
+| Library `.py` modules under `pyro/` | 38 | — | see §2 |
+| Example scripts | 195 | 44 | ~151 demos not yet ported |
+| Course notebooks | 3 | 7 (new topics) | different mix |
+| Catalog plant classes | 40+ | 40+ | **0 math gaps** (QA'd) |
+| Control law modules | 5 files | 3 files | 2+ files missing |
+| Planning modules | 6 files | 1 trajopt stack | 4+ areas missing |
+| Analysis modules | 4 files | 5 tools | mostly ported; cost variants gap |
+| Tools / interfaces | 2 files | 0 | 2 missing |
+
+**Verdict:** catalog migration is complete; **tools, planning, control nonlinear/robot
+laws, interfaces, and ~75% of pyro demos** remain before calling pyro 2.0 done.
+
+---
+
+## 1. Already ported (do not re-port)
+
+### 1.1 Catalog plants (`pyro/dynamic/` → `minilink/dynamics/catalog/`)
+
+All pyro plant EoMs are ported and term-by-term QA'd. See
+[catalog-migration-notes.md](catalog-migration-notes.md).
+
+- [x] Integrators (`Simple` / `Double` / `Triple`)
+- [x] `VanderPol`
+- [x] Pendulums (`Pendulum`, `InvertedPendulum`, `DoublePendulum`, `Acrobot`,
+  `TwoIndependentPendulums`)
+- [x] Cart-pole family (`CartPole`, `RotatingCartPole`, `UnderactuatedRotatingCartPole`,
+  JAX twin)
+- [x] Mass–spring–damper (`Single`…`Three`, floating variants)
+- [x] `MountainCar`
+- [x] Propulsion cars (slip + torque inputs)
+- [x] Steering (`KinematicBicycle`, `KinematicCar`, `ConstantSpeedKinematicCar`,
+  holonomic 2D/3D, `UdeSRacecar`)
+- [x] `DynamicBicycle` (+ `LinearTire`, SL/JAX variants)
+- [x] `QuarterCarOnRoughTerrain` (suspension)
+- [x] Aerial (`Rocket`, `Drone2D`, side thruster, speed-controlled, helicopter tunnel)
+- [x] `Plane2D`
+- [x] `Boat2D`, `Boat2DWithCurrent`
+- [x] Manipulators (`OneLink`…`FiveLink`, speed-controlled)
+
+### 1.2 Blocks and routing (`pyro/planning/filters` partial)
+
+- [x] `Sum`, `Gain`, `Mux`, `Demux` (`blocks/routing.py`)
+- [x] `Saturation`, `DeadZone`, `Relay` (`blocks/nonlinear.py`)
+- [x] `LowPassFilter`, `NotchFilter`, `Washout` (`blocks/filters.py`)
+- [x] `TransferFunction` (`blocks/transfer_function.py`)
+- [x] `Integrator` (`blocks/basic.py`)
+- [x] `TrajectorySource` (replaces pyro `OpenLoopController`)
+- [x] `NeuralNetwork` 1-hidden-layer MLP (`blocks/neural.py`) — **no pyro equivalent**
+
+### 1.3 Linear control (`pyro/control/linear.py`, `lqr.py`)
+
+- [x] `ProportionalController` (SISO + MIMO)
+- [x] `PDController`
+- [x] `PIDController` (continuous, no anti-windup in `control/linear.py`)
+- [x] `FilteredPIDController` with anti-windup (`control/pid.py`) — **minilink extra**
+- [x] `LinearStateFeedbackController` / `LinearFeedbackController`
+- [x] `lqr_gain`, `lqr`, `lqr_at_operating_point` (`control/lqr.py`)
+
+### 1.4 Analysis tools (`pyro/analysis/` + `pyro/dynamic/statespace.py`)
+
+- [x] `linearize_matrices`, `linearize` → `LTISystem` (FD + JAX)
+- [x] Controllability / observability (`analysis/structural.py`)
+- [x] `find_equilibrium` (`analysis/equilibria.py`)
+- [x] Modal analysis + animation (`analysis/modal.py`)
+- [x] Selected-channel Bode (`analysis/frequency.py`)
+- [x] Phase-plane plotting (`graphical/phase_plane/`) — basic `PhasePlot` parity
+
+### 1.5 Simulation, trajectory, costs
+
+- [x] `Trajectory` (`core/trajectory.py`)
+- [x] `Simulator` + solvers (`simulation/`)
+- [x] Quadratic / time costs (`core/costs.py`)
+- [x] Diagram compile + NumPy/JAX evaluators (`core/compile/`)
+- [x] Parametric tier `f_p`, `jacobian_f_params` (diagram + identification prototype)
+
+### 1.6 Planning (partial)
+
+- [x] Direct collocation trajopt (`planning/trajectory_optimization/`)
+- [x] Multiple shooting, shooting, live plot hooks
+- [x] MPC demos on dynamic bicycle (minilink **extra** — no pyro MPC library)
+
+### 1.7 Graphics / kinematics (`pyro/kinematic/`, `pyro/analysis/graphical.py`)
+
+- [x] 2D transforms, arrows, primitives (`graphical/animation/primitives.py`)
+- [x] Matplotlib / Plotly / Meshcat / Pygame renderers
+- [x] `animate()`, `plot_trajectory()`, diagram export
+- [x] Interactive animation demo (`examples/scripts/animation/demo_interactive.py`)
+
+### 1.8 Framework (no direct pyro module — minilink additions)
+
+- [x] `DiagramSystem`, composition (`+`, `>>`, `@`, autowire)
+- [x] `MathematicalProgram` + `Optimizer` (SciPy + Ipopt)
+- [x] JAX identification prototype (`demo_params_gradient.py`)
+- [x] Symbolic mechanics quarantine (`symbolic/mechanics/`)
+- [x] Contact / ANCF tire engines (experimental, no pyro equivalent)
+
+---
+
+## 2. Missing library tools (pyro module → minilink home)
+
+### 2.1 Control — high priority
+
+| Pyro symbol | Proposed minilink home | Pyro demo refs (approx.) | Status |
+| --- | --- | ---: | --- |
+| `ComputedTorqueController` | `control/computed_torque.py` | 23 | [ ] |
+| `SlidingModeController` | `control/sliding_mode.py` | 6 | [ ] |
+| `TrajectoryLQRController` | `control/trajectory_lqr.py` | 3 + courses | [ ] |
+| `JointPD`, `EndEffectorPD` | `control/robotic.py` | 15+ | [ ] |
+| `JointPID`, `EndEffectorPID` | `control/robotic.py` | 10+ | [ ] |
+| `EndEffectorKinematicController` | `control/robotic.py` | 8+ | [ ] |
+| `EndEffectorKinematicControllerWithNullSpaceTask` | `control/robotic.py` | 3 + 1 notebook | [ ] |
+| `linearize_and_synthesize_lqr_controller` | tool in `analysis/` (not `control/`) | several | [ ] workaround: two-step demo exists |
+| `stable_baseline3_controller` | `interfaces/` or `control/` thin wrapper | 7+ | [ ] |
+| NN policy blocks | `control/neural.py` + `blocks/neural/` | 0 in pyro | [ ] minilink-only |
+| MPC controller factory | `control/mpc.py` | 0 in pyro | [ ] minilink-only |
+
+**Deferred from first tranche** (already logged in tool-migration-notes):
+
+- [ ] `Switch` routing block (selection semantics undecided)
+- [ ] `RateLimiter`, `Hysteresis` stateful nonlinear blocks
+- [ ] Plain `PIDController` anti-windup in `control/linear.py` (use `FilteredPIDController` today)
+
+### 2.2 Planning — high priority
+
+| Pyro symbol | Proposed minilink home | Pyro demo refs (approx.) | Status |
+| --- | --- | ---: | --- |
+| `RRT` | `planning/search/rrt.py` | 20 | [ ] redesign (stubs removed) |
+| `DynamicProgramming` | `planning/policy_synthesis/dp.py` | 29 | [ ] redesign (stubs removed) |
+| `LookUpTableController` | `planning/policy_synthesis/lookup_policy.py` | bundled with DP | [ ] |
+| `GridDynamicSystem` | `planning/policy_synthesis/discretizer.py` | bundled with DP | [ ] |
+| `PolicyEvaluator` (+ lookup variants) | `planning/policy_synthesis/policy_eval.py` | 4 | [ ] |
+| `SingleAxisPolynomialTrajectoryGenerator` | `planning/trajectory_generation/polynomial.py` | 2 | [ ] |
+| `MultiPointSingleAxisPolynomialTrajectoryGenerator` | same | 2 | [ ] |
+| `TrajectoryFilter` (Butterworth `filtfilt`) | `planning/trajectory_generation/filter.py` or `analysis/` | 0 standalone | [ ] |
+| `DirectCollocationTrajectoryOptimisation` | `planning/trajectory_optimization/` | 18 | [x] ported (JAX/Ipopt path) |
+
+**Design note:** pyro DP/RRT operate on **continuous plants + discrete grids/trees**.
+Minilink declared continuous-time simulation only; DP/RRT need an explicit
+**offline/discrete planning** contract before port (see §4).
+
+### 2.3 Estimation — medium priority
+
+| Pyro symbol | Proposed minilink home | Pyro demo refs | Status |
+| --- | --- | ---: | --- |
+| `StateObserver` (Luenberger) | `estimation/luenberger.py` | 1 (`cartpole_LQG`) | [ ] |
+| `ObservedSystem` | diagram composition recipe | 1 | [ ] |
+| EKF | `estimation/ekf.py` (uses `analysis/linearize`) | 0 | [ ] |
+| Kalman filter design | `estimation/kalman.py` | 0 | [ ] |
+| Online RLS / adaptive | `estimation/recursive.py` | 5 example-local | [ ] |
+
+### 2.4 Identification — medium priority
+
+| Need | Proposed home | Pyro equivalent | Status |
+| --- | --- | ---: | --- |
+| Batch param fitting | `identification/fitting.py` | manual in examples | [ ] |
+| Equation-error loss | `identification/fitting.py` | — | [ ] prototype in `demo_params_gradient.py` |
+| Rollout / prediction-error loss | `identification/fitting.py` | RL/DP examples | [ ] |
+| NN weight fitting | same API as physical params | — | [ ] minilink-only |
+
+### 2.5 Interfaces — medium priority
+
+| Pyro symbol | Proposed minilink home | Pyro demo refs | Status |
+| --- | --- | ---: | --- |
+| `Sys2Gym` | `interfaces/gymnasium.py` | 12+ RL | [ ] |
+| `stable_baseline3_controller` | `interfaces/` + `control/` | 7 | [ ] |
+| `InteractiveContinuousDynamicSystem` | defer / `graphical/` only | 10 games | [ ] see §4 |
+| Flax / PyTorch model import | `interfaces/flax.py`, `torch.py` | 0 | [ ] minilink-only |
+| FMI / cosimulation | `interfaces/` | 0 | [ ] |
+
+### 2.6 Analysis — lower priority (extensions)
+
+| Pyro symbol | Proposed minilink home | Status |
+| --- | --- | --- |
+| `QuadraticCostFunctionWithDomainCheck` | `core/costs.py` or `planning/problems.py` | [ ] |
+| `Reachability` cost | same | [ ] |
+| `QuadraticCostFunctionVectorized` | trajopt evaluator | [ ] partial via JAX |
+| `PhasePlot3` | `graphical/phase_plane/` | [ ] deferred |
+| `ss2tf` | `analysis/frequency.py` | [ ] |
+| Pole-zero, Nyquist, margins | `analysis/frequency.py` | [ ] ROADMAP §5 |
+| `linearize_and_lqr` one-shot tool | `analysis/` design tool | [ ] |
+
+### 2.7 Catalog / plant gaps (not EoM — capability gaps)
+
+| Pyro class | Issue | Proposed approach | Status |
+| --- | --- | --- | --- |
+| `*withObstacles` (4 classes) | collision checks in plant | engine or `planning/` collision, not per-plant | [ ] |
+| `Pacejka` tire | magic formula | `dynamics/catalog/vehicles/` or tire submodule | [ ] deferred |
+| `TireModel` abstraction | interface only | optional if Pacejka lands | [ ] |
+| `StochasticSystemWrapper` | process noise | `estimation/` or port noise sources | [ ] |
+| `NoiseSignal` | noise time series | extend `blocks/sources` or noise ports | [ ] partial (`demo_noise_ports`) |
+| `MechanicalSystemWithPositionInputs` | mixed inputs | named ports per DESIGN (no subclass) | [x] by design |
+
+### 2.8 Pyro API sugar — document, don't necessarily port
+
+| Pyro pattern | Minilink replacement | Status |
+| --- | --- | --- |
+| `ctl + plant` → `ClosedLoopSystem` | `controller >> plant` or `DiagramSystem` | [x] different API |
+| `ClosedLoopSystem.compute_trajectory` | `diagram.compute_trajectory` | [x] |
+| `convert_to_gymnasium()` on plant | `interfaces/gymnasium.py` | [ ] |
+| `convert_to_pygame()` on plant | `graphical/animation` + pygame renderer | [~] partial |
+
+---
+
+## 3. Missing demos — port checklist by technique
+
+Use this as the **example port backlog**. A demo is "done" when an equivalent
+`examples/scripts/` (or notebook) workflow exists in minilink using the new
+framework APIs (diagrams, compile, tools) — not a line-by-line translation.
+
+### 3.1 By control / planning technique
+
+| Technique | Pyro scripts | Minilink coverage today | Todo |
+| --- | ---: | --- | --- |
+| LQR stabilization | ~16 | `cartpole_lqr_stabilization.py`, `demo_linearize.py` | [ ] port remaining plants (pendulum, MSD, drone, rocket, plane, double pendulum, acrobot) |
+| PID / filtered PID | ~32 | `demo_filtered_pid_anti_windup.py`, MSD in catalog `__main__` | [ ] robot joint/effector PID demos |
+| Computed torque | 23 | none | [ ] blocked on `control/computed_torque.py` |
+| Sliding mode | 6 | none | [ ] blocked on `control/sliding_mode.py` |
+| Trajectory LQR / stabilization | 3 | none | [ ] blocked on `control/trajectory_lqr.py` |
+| Impedance control | 9 | none | [ ] example-local in pyro; needs `control/robotic.py` |
+| Adaptive control | 5 | none | [ ] example-local; needs `estimation/recursive.py` or dedicated control |
+| Value iteration / DP | 29 | none | [ ] blocked on policy synthesis redesign |
+| RRT | 20 | none | [ ] blocked on `planning/search/rrt.py` |
+| Trajectory optimization | ~18 | 5+ trajopt + MPC demos | [ ] port pendulum/cartpole/double-pendulum/acrobot/mountain-car/drone/plane car demos not yet covered |
+| Differential flatness / min-snap | 4 | none | [ ] blocked on `planning/trajectory_generation/` |
+| RL / PPO / Gym | 12 | `demo_neural_controller_jax.py` only | [ ] blocked on `interfaces/gymnasium.py` |
+| Robot kinematic / nullspace | ~12 | none | [ ] blocked on `control/robotic.py` |
+| Open-loop / traj replay | 3 | `TrajectorySource` | [ ] port explicit open-loop pendulum/double-pendulum demos |
+| Transfer function / Bode | 2 | `demo_bode.py` | [ ] port `pendulum_frequency_response`, `mass_with_pid` |
+| Policy evaluation / reachability | 4 | none | [ ] blocked on DP |
+| Modal / eigenmodes | ~8 | `demo_modal.py` | [ ] port `*_modes.py`, `*_eigen_modes.py` per plant |
+| LQG / observer | 1 | none | [ ] blocked on `estimation/luenberger.py` |
+| Feedback linearization | 1 | none | [ ] low priority; specialized |
+| Games / pygame / joystick | ~10 | `demo_interactive.py` | [ ] port or explicitly drop |
+| Plant showcase only | ~25 | many catalog `__main__` + animation demos | [ ] audit which are still needed as scripts |
+| Course / project bundles | ~30 | partial | [ ] lower priority than `demos_by_system` |
+
+### 3.2 Pyro `demos_by_system/` — per-plant demo gaps
+
+| Plant folder | Pyro scripts | Ported? |
+| --- | ---: | --- |
+| `pendulum_simple` | 14 | [ ] mostly missing (only catalog `__main__`) |
+| `pendulum_double` | 14 | [ ] |
+| `cartpole` | 5 | [~] `cartpole_lqr_stabilization.py` + trajopt |
+| `cartpole_rotating` | 8 | [ ] |
+| `mass_spring_damper` | 8 | [~] modal demo exists; PID/LQR per variant missing |
+| `robot_arm_1dof` | 1 | [ ] |
+| `robot_arm_2dof` | 9 | [ ] |
+| `robot_arm_3dof` | 5 | [ ] |
+| `robot_arm_5dof` | 4 | [ ] |
+| `car_steering` | 9 | [~] bicycle path-tracking demos exist |
+| `car_dynamic` | 3 | [~] `demo_dynamic_bicycle.py` |
+| `car_propulsion` | 2 | [ ] |
+| `mountain_car` | 1 | [ ] |
+| `drone` | 3 | [ ] |
+| `plane` | 2 | [ ] |
+| `rocket` | 2 | [ ] |
+| `boat` | 2 | [ ] |
+| `holonomic_mobile_robot` | 3 | [ ] |
+| `acrobot` | 2 | [ ] |
+| `equations` | 6 | [~] partial via integrator/oscillator catalog |
+| `suspension` | 1 | [ ] |
+
+### 3.3 Minilink demos with no pyro counterpart (keep)
+
+These are **not** gaps — they validate new framework capabilities:
+
+- Diagram compiling, autowire, nested loops, noise ports
+- MPC + rate-MPC on dynamic bicycle (6 scripts)
+- JAX optimization / identification / neural controller
+- Physics engine / ANCF tire / contact
+- Symbolic quadruple pendulum
+- Showcase / overview notebooks
+
+---
+
+## 4. Explicitly out of scope (do not port as-is)
+
+Recorded minilink decisions that conflict with pyro features:
+
+| Topic | Decision | Pyro surface |
+| --- | --- | --- |
+| Discrete-time framework | Continuous-time only | `GridDynamicSystem.dt`, DP time stepping |
+| Digital control / ZOH / delays | Out of scope | — |
+| RNNs / LSTM | Out of scope | — |
+| Mixed-rate simulation | Out of scope | — |
+| Differentiable rollouts (library) | Out of scope | demo-level JAX OK |
+| Hybrid events | Out of scope | — |
+| Pygame game framework | No first-class port | `sys2game`, `*game.py` |
+| DP / RRT stubs | Removed; redesign first | `planning/dynamicprogramming.py`, `randomtree.py` |
+
+**Action items for pyro 2.0 closure:**
+
+- [ ] User sign-off: DP/RRT return as **offline planning tools** on continuous plants
+- [ ] User sign-off: drop or replace **~10 game demos** with `demo_interactive` pattern
+- [ ] User sign-off: **RL/Gym** trains outside; minilink only supplies `interfaces/gymnasium.py`
+
+---
+
+## 5. Recommended port phases (pyro 2.0 finish line)
+
+### Phase A — Unblock the largest demo surfaces
+
+1. [ ] `control/computed_torque.py`
+2. [ ] `control/sliding_mode.py`
+3. [ ] `control/robotic.py` (joint/effector PD, PID, kinematic, nullspace)
+4. [ ] Port top robot demos: 2-link computed torque, joint PD, effector PD, kinematic
+5. [ ] Port top pendulum demos: PID, computed torque, sliding mode, LQR
+
+### Phase B — Planning beyond trajopt
+
+6. [ ] Architectural review: DP + grid discretizer contract
+7. [ ] `planning/policy_synthesis/` (DP, lookup policy, policy evaluator)
+8. [ ] Architectural review: RRT state space + collision hook
+9. [ ] `planning/search/rrt.py`
+10. [ ] `planning/trajectory_generation/` (polynomial / min-snap)
+11. [ ] `control/trajectory_lqr.py`
+12. [ ] Port DP/RRT demo subset (pendulum, car, holonomic robot)
+
+### Phase C — Estimation, identification, interfaces
+
+13. [ ] `estimation/luenberger.py` + LQG diagram recipe
+14. [ ] `estimation/kalman.py`
+15. [ ] `identification/fitting.py` (unify physical + NN params)
+16. [ ] `interfaces/gymnasium.py`
+17. [ ] Port RL demo subset or document SB3-outside workflow
+
+### Phase D — Analysis and frequency completion
+
+18. [ ] `analysis/frequency.py`: pole-zero, Nyquist, margins, `ss2tf`
+19. [ ] Reachability / domain-check costs for planning
+20. [ ] Phase-plane 3D / Plotly follow-ups (if still wanted)
+
+### Phase E — Catalog capability gaps
+
+21. [ ] Obstacle collision layer (replace `*withObstacles` plants)
+22. [ ] `Pacejka` tire (optional)
+23. [ ] Stochastic forcing / noise source blocks
+
+### Phase F — Demo audit and courses
+
+24. [ ] Port remaining `demos_by_system/` showcase scripts (plant-only)
+25. [ ] Port `demos_by_tool/transfer_functions/`
+26. [ ] Decide fate of `examples/courses/` and `examples/projects/` (ugv, asimov, wcrt, adaptive)
+
+### Phase G — Framework polish (pyro 2.0 release criteria)
+
+27. [ ] Public export policy (`minilink/__init__.py`)
+28. [ ] Compile evaluator API review (TRL 4 → 7)
+29. [ ] Graphics kinematic composition refactor (ROADMAP review queue)
+30. [ ] Document pyro → minilink API mapping (README migration guide)
+31. [ ] TRL 8 demos for each major tool band
+32. [ ] Full pytest coverage for ported tools
+
+---
+
+## 6. Quick reference — pyro file → minilink status
+
+| Pyro module | Minilink | Status |
+| --- | --- | --- |
+| `dynamic/*` plants | `dynamics/catalog/` | **Done** |
+| `dynamic/statespace.py` | `abstraction/state_space.py` + `analysis/linearize.py` | **Done** |
+| `dynamic/stochastic.py` | — | **Missing** |
+| `control/linear.py` | `control/linear.py`, `control/pid.py` | **Done** |
+| `control/lqr.py` | `control/lqr.py` | **Done** (no traj LQR) |
+| `control/nonlinear.py` | — | **Missing** |
+| `control/robotcontrollers.py` | — | **Missing** |
+| `control/reinforcementlearning.py` | — | **Missing** |
+| `control/controller.py` | `core/diagram.py`, `core/composition.py` | **Replaced** (different API) |
+| `planning/trajectoryoptimisation.py` | `planning/trajectory_optimization/` | **Done** |
+| `planning/trajectorygeneration.py` | — | **Missing** |
+| `planning/dynamicprogramming.py` | — | **Missing** (redesign) |
+| `planning/randomtree.py` | — | **Missing** (redesign) |
+| `planning/discretizer.py` | — | **Missing** |
+| `planning/filters.py` | — | **Missing** |
+| `planning/plan.py` | `blocks/sources.TrajectorySource` | **Done** |
+| `analysis/simulation.py` | `simulation/`, `core/trajectory.py` | **Done** |
+| `analysis/costfunction.py` | `core/costs.py` | **Partial** |
+| `analysis/phaseanalysis.py` | `graphical/phase_plane/` | **Partial** |
+| `analysis/graphical.py` | `graphical/` | **Done** (different structure) |
+| `tools/sys2gym.py` | — | **Missing** |
+| `tools/sys2game.py` | — | **Out of scope** |
+| `kinematic/*` | `graphical/animation/primitives.py` | **Done** |
+
+---
+
+## 7. Definition of done — pyro 2.0
+
+Treat pyro 2.0 (minilink) as **feature-complete** when:
+
+1. Every **in-scope** pyro library module has a minilink home or a documented replacement.
+2. Every **in-scope** pyro `demos_by_system/` plant has at least one representative
+   closed-loop demo in `examples/scripts/`.
+3. DP/RRT either land with approved architecture **or** are explicitly dropped with
+   migrated alternatives documented.
+4. Robot control suite (`computed_torque`, `sliding_mode`, `robotic`) reaches TRL ≥ 6.
+5. Estimation seed (Luenberger) + identification `fitting.py` exist for the
+   params-gradient workflow shown in pyro's parameter-ID examples.
+6. README includes a **pyro migration guide** (API mapping table).
+
+Until then, use this file as the master unchecked todo.

--- a/minilink/dynamics/abstraction/manipulator.py
+++ b/minilink/dynamics/abstraction/manipulator.py
@@ -1,0 +1,88 @@
+"""
+Serial manipulators: mechanical dynamics plus task-space kinematics.
+
+Equation of motion (from :class:`~minilink.dynamics.abstraction.mechanical.MechanicalSystem`)::
+
+    H(q) q̈ + C(q, q̇) q̇ + g(q) = τ
+
+Kinematics (this module)::
+
+    p = f(q)
+    ṗ = J(q) q̇
+
+Joint-space outputs ``q``, ``dq`` live on :class:`MechanicalSystem`.
+Task-space outputs ``p``, ``pdot`` are added here.
+
+See ``docs/plans/manipulator-abstraction.md``.
+"""
+
+from minilink.core.backends import array_module
+from minilink.dynamics.abstraction.mechanical import MechanicalSystem
+
+
+class Manipulator(MechanicalSystem):
+    """
+    Serial manipulator with task-space kinematic outputs.
+
+    Dynamics follow :class:`MechanicalSystem`. Subclasses override
+    :meth:`forward_kinematics` and :meth:`J`.
+
+    Output ports
+    ------------
+    q, dq :
+        Joint position and velocity (from :class:`MechanicalSystem`).
+    p, pdot :
+        Task position ``p = f(q)`` and velocity ``ṗ = J(q) q̇``.
+    y, x :
+        Full state ``[q; q̇]`` (backward compatible).
+
+    Input port ``u`` carries joint torques ``τ``.
+    """
+
+    def __init__(self, dof=1, actuators=None, task_dim=2):
+        super().__init__(dof=dof, actuators=actuators)
+        self.task_dim = int(task_dim)
+        if self.task_dim <= 0:
+            raise ValueError("task_dim must be positive")
+
+        self.name = f"{dof}DoF Manipulator"
+
+        p_labels = [f"p{i}" for i in range(self.task_dim)]
+        pdot_labels = [f"pdot{i}" for i in range(self.task_dim)]
+        self.add_output_port(
+            "p",
+            dim=self.task_dim,
+            function=self.h_p,
+            dependencies=(),
+            labels=p_labels,
+            units=["[m]"] * self.task_dim,
+        )
+        self.add_output_port(
+            "pdot",
+            dim=self.task_dim,
+            function=self.h_pdot,
+            dependencies=(),
+            labels=pdot_labels,
+            units=["[m/s]"] * self.task_dim,
+        )
+
+    def forward_kinematics(self, q, params=None):
+        """Task-space position ``p = f(q)``, shape ``(task_dim,)``."""
+        xp = array_module(q)
+        return xp.zeros(self.task_dim)
+
+    def J(self, q, params=None):
+        """Manipulator Jacobian ``∂p/∂q``, shape ``(task_dim, dof)``."""
+        xp = array_module(q)
+        return xp.zeros((self.task_dim, self.dof))
+
+    def h_p(self, x, u, t=0, params=None):
+        q, dq = self.x2q(x)
+        return self.forward_kinematics(q, params)
+
+    def h_pdot(self, x, u, t=0, params=None):
+        q, dq = self.x2q(x)
+        J = self.J(q, params)
+
+        # task-space velocity: ṗ = J(q) q̇
+        return J @ dq

--- a/minilink/dynamics/abstraction/mechanical.py
+++ b/minilink/dynamics/abstraction/mechanical.py
@@ -77,6 +77,21 @@ class MechanicalSystem(DynamicSystem):
         self.outputs["y"].labels = list(self.state.labels)
         self.outputs["y"].units = list(self.state.units)
 
+        self.add_output_port("q", dim=dof, function=self.h_q, dependencies=())
+        self.add_output_port("dq", dim=dof, function=self.h_dq, dependencies=())
+        self.outputs["q"].labels = self.state.labels[:dof]
+        self.outputs["q"].units = self.state.units[:dof]
+        self.outputs["dq"].labels = self.state.labels[dof:]
+        self.outputs["dq"].units = self.state.units[dof:]
+
+    def h_q(self, x, u, t=0, params=None):
+        q, _ = self.x2q(x)
+        return q
+
+    def h_dq(self, x, u, t=0, params=None):
+        _, dq = self.x2q(x)
+        return dq
+
     def H(self, q, params=None):
         """Inertia matrix, shape (dof, dof). Kinetic energy = 0.5 * dq^T H(q) dq."""
         xp = array_module(q)

--- a/tests/unittest/test_manipulator.py
+++ b/tests/unittest/test_manipulator.py
@@ -1,0 +1,54 @@
+import unittest
+
+import numpy as np
+
+from minilink.dynamics.abstraction.manipulator import Manipulator
+from minilink.dynamics.abstraction.mechanical import MechanicalSystem
+
+
+class TestMechanicalJointPorts(unittest.TestCase):
+    def test_q_and_dq_ports_match_state(self):
+        sys = MechanicalSystem(dof=2)
+        x = np.array([0.1, -0.2, 0.3, 0.4])
+
+        q = sys.h_q(x, np.zeros(sys.m))
+        dq = sys.h_dq(x, np.zeros(sys.m))
+
+        np.testing.assert_allclose(q, x[:2])
+        np.testing.assert_allclose(dq, x[2:])
+        self.assertEqual(sys.outputs["q"].dim, 2)
+        self.assertEqual(sys.outputs["dq"].dim, 2)
+
+
+class TestManipulator(unittest.TestCase):
+    def test_default_kinematics_ports_are_zero(self):
+        sys = Manipulator(dof=2, task_dim=2)
+        x = np.array([0.2, -0.1, 0.0, 0.0])
+        u = np.zeros(sys.m)
+
+        p = sys.h_p(x, u)
+        pdot = sys.h_pdot(x, u)
+
+        np.testing.assert_allclose(p, np.zeros(2))
+        np.testing.assert_allclose(pdot, np.zeros(2))
+
+    def test_subclass_forward_kinematics_and_jacobian(self):
+        class TwoLinkStub(Manipulator):
+            def forward_kinematics(self, q, params=None):
+                return np.array([q[0], q[0] + q[1]])
+
+            def J(self, q, params=None):
+                return np.array([[1.0, 0.0], [1.0, 1.0]])
+
+        sys = TwoLinkStub(dof=2, task_dim=2)
+        q = np.array([0.5, -0.25])
+        dq = np.array([1.0, 2.0])
+        x = sys.q2x(q, dq)
+        u = np.zeros(sys.m)
+
+        np.testing.assert_allclose(sys.h_p(x, u), np.array([0.5, 0.25]))
+        np.testing.assert_allclose(sys.h_pdot(x, u), np.array([1.0, 3.0]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pyro 2.0 planning plus the manipulator abstraction scaffold.

### Planning docs

- `docs/plans/pyro-port-gap-todo.md` — master port gap checklist
- `docs/plans/manipulator-abstraction.md` — textbook port/method contract + **file layout**
- `ROADMAP.md` — pyro 2.0 phases and abstraction status

### Code (abstraction scaffold)

**`mechanical.py`** — `MechanicalSystem` joint ports `q`, `dq` + `h_q`, `h_dq`

**`manipulator.py`** (distinct file) — `Manipulator` with:
- task ports `p`, `pdot`
- `forward_kinematics(q)`, `J(q)`
- `h_p`, `h_pdot` implementing `p = f(q)`, `ṗ = J(q) q̇`

**Tests:** `tests/unittest/test_manipulator.py`

### File layout

| File | Class |
| --- | --- |
| `dynamics/abstraction/mechanical.py` | `MechanicalSystem` |
| `dynamics/abstraction/manipulator.py` | `Manipulator` |

Catalog `arms.py` rebase not yet done.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fd18d06f-b9d1-493c-a0df-1b3d5132d009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fd18d06f-b9d1-493c-a0df-1b3d5132d009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

