### PR TITLE
Add workspace cost field visualization for MPC tuning

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -331,6 +331,11 @@ from waypoint polylines via `from_waypoints` (default `kind="polyline"`), wrappe
 clearance (subtract body radius). Compose with obstacles:
 `X = bounds & scene.clearance_field(body).as_constraint() & track.corridor_field(body).as_constraint()`.
 
+**Workspace cost raster** (`grid.sample_field_costs`, `plotting.plot_cost_field` /
+`plot_cost_field_3d` / `plot_cost_field_exports`): rasterize shaped ``FieldCost`` terms
+at workspace points ``p = (x, y)`` with a **point probe** body (heading-independent).
+Build viz costs with ``bind(sys, point_probe())``; MPC may still use ``car_outline``.
+
 **Search / RRT** (`planning/search/`): `RRTPlanner(Planner)` owns the invariant loop and
 sources every concern from the problem — collision `problem.X.contains` (optional
 orchestrator `edge_resolution` densification along edges), goal `problem.Xf`/`x_goal`,

--- a/examples/scripts/mpc/demo_dynamic_bicycle_rate_mpc_wide_circuit_lap.py
+++ b/examples/scripts/mpc/demo_dynamic_bicycle_rate_mpc_wide_circuit_lap.py
@@ -27,9 +27,11 @@ from minilink.planning.mpc import (
     MPCPlanner,
 )
 from minilink.planning.problems import PlanningProblem
-from minilink.planning.spatial.collision import bind, car_outline
+from minilink.planning.spatial.collision import bind, car_outline, point_probe
+from minilink.planning.spatial.grid import pad_bounds, sample_field_costs
 from minilink.planning.spatial.overlays import TrackCorridorOverlay
 from minilink.planning.spatial.paths import from_waypoints
+from minilink.planning.spatial.plotting import plot_cost_field_exports
 from minilink.planning.spatial.scene import Scene
 from minilink.planning.spatial.shaping import (
     inverse_barrier,
@@ -98,6 +100,7 @@ W_REAR_DOT_MAX = 80.0
 DELTA_DOT_MAX = 2.0
 CAMERA_SCALE = 18.0
 PLOT_MARGIN = 3.0
+COST_FIELD_MARGIN = 6.0
 
 
 def _quarter_arc_waypoints(cx, cy, radius, angle_start, n=10):
@@ -221,6 +224,7 @@ track = ReferenceTrack(
     from_waypoints(REFERENCE_WAYPOINTS), half_width=CORRIDOR_HALF_WIDTH
 )
 body = bind(sys_mpc, car_outline(length=2.4, width=0.2, margin=0.05))
+probe = bind(sys_mpc, point_probe())
 scene = Scene(
     obstacles=tuple(Sphere(center, keepout_radius) for center in OBSTACLE_CENTERS)
 )
@@ -245,7 +249,20 @@ obstacle_cost = scene.clearance_field(body).as_cost(
     weight=OBSTACLE_REPULSION_WEIGHT,
     shaping=inverse_barrier(epsilon=OBSTACLE_REPULSION_EPS),
 )
-
+# Workspace heatmaps: point probe at each (x, y) — heading-independent tuning view.
+# MPC costs above still use car_outline for the planner body.
+path_cost_viz = track.distance_field(probe).as_cost(
+    weight=PATH_COST_WEIGHT,
+    shaping=quadratic_excess(threshold=0.1),
+)
+corridor_cost_viz = track.corridor_field(probe).as_cost(
+    weight=CORRIDOR_COST_WEIGHT,
+    shaping=quadratic_hinge(threshold=0.0),
+)
+obstacle_cost_viz = scene.clearance_field(probe).as_cost(
+    weight=OBSTACLE_REPULSION_WEIGHT,
+    shaping=inverse_barrier(epsilon=OBSTACLE_REPULSION_EPS),
+)
 cost = stability_cost + path_cost + corridor_cost + obstacle_cost
 
 s_start, _ = loop_track.path.project(START_XY)
@@ -401,6 +418,25 @@ ax.scatter(
 ax.legend(loc="upper left", fontsize=8)
 fig.tight_layout()
 plt.show()
+
+COST_FIELD_BOUNDS = pad_bounds(PLOT_BOUNDS, COST_FIELD_MARGIN - PLOT_MARGIN)
+_cost_kw = dict(bounds=COST_FIELD_BOUNDS, state_dim=sys_mpc.n)
+
+plot_cost_field_exports(
+    {
+        "path": sample_field_costs([path_cost_viz], **_cost_kw),
+        "corridor": sample_field_costs([corridor_cost_viz], **_cost_kw),
+        "obstacle": sample_field_costs([obstacle_cost_viz], **_cost_kw),
+        "combined": sample_field_costs(
+            [path_cost_viz, corridor_cost_viz, obstacle_cost_viz], **_cost_kw
+        ),
+    },
+    track=loop_track,
+    scene=scene,
+    overlay_bounds=PLOT_BOUNDS,
+    traj=traj.x[0:2, :],
+    log_scale=True,
+)
 
 
 # --- Animation ---

--- a/minilink/planning/spatial/grid.py
+++ b/minilink/planning/spatial/grid.py
@@ -4,11 +4,12 @@ Backend-neutral rasters of a scalar field on a 2-D grid.
 :func:`sample_grid` evaluates a scalar query ``fn(p, t, params)`` over an
 axis-aligned grid and returns a :class:`FieldGrid` of plain NumPy arrays — no
 matplotlib. Scenes and state fields use it to rasterize clearance and
-cost-density queries for heatmaps and grid planners; rendering lives in
+cost-density queries for heatmaps; :func:`sample_field_costs` rasterizes shaped
+``FieldCost`` terms for MPC tuning plots in
 :mod:`minilink.planning.spatial.plotting`.
 """
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
 import numpy as np
@@ -76,3 +77,42 @@ def sample_grid(
         for i, x in enumerate(xs):
             Z[j, i] = float(fn(np.array([x, y]), t, params))
     return FieldGrid(xs, ys, Z)
+
+
+def pad_bounds(bounds, padding: float):
+    """Expand axis-aligned ``((x_lo, x_hi), (y_lo, y_hi))`` bounds by ``padding``."""
+    (x_lo, x_hi), (y_lo, y_hi) = bounds
+    pad = float(padding)
+    return ((x_lo - pad, x_hi + pad), (y_lo - pad, y_hi + pad))
+
+
+def sample_field_costs(
+    costs: Sequence,
+    *,
+    bounds,
+    grid: tuple = (200, 200),
+    state_dim: int = 2,
+    u=None,
+    t: float = 0.0,
+    params=None,
+) -> FieldGrid:
+    """
+    Rasterize shaped ``FieldCost`` terms on a workspace XY grid.
+
+    Each cell is the cost of a **workspace point** ``p = (x, y)`` using a
+    **point probe** — build costs with ``bind(sys, point_probe())`` so the
+    field does not depend on robot heading or body extent. ``state_dim`` must
+    match the planner plant state size (``sys.n``).
+    """
+    if not costs:
+        raise ValueError("sample_field_costs requires at least one cost")
+
+    u_use = np.zeros(1) if u is None else u
+    x = np.zeros(int(state_dim))
+
+    def fn(p, t_query=0.0, params_query=None):
+        x[0] = p[0]
+        x[1] = p[1]
+        return sum(float(c.g(x, u_use, t=t_query, params=params_query)) for c in costs)
+
+    return sample_grid(fn, bounds, grid=grid, t=t, params=params)

--- a/minilink/planning/spatial/plotting.py
+++ b/minilink/planning/spatial/plotting.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from minilink.core.geometry import Box, Inflated, Sphere, Union
 from minilink.planning.spatial.collision import iter_probes
-from minilink.planning.spatial.grid import sample_grid
+from minilink.planning.spatial.grid import FieldGrid, sample_grid
 from minilink.planning.spatial.workspace_fields import GaussianField
 
 # Public API
@@ -136,6 +136,310 @@ def plot_scene(
         plt.show()
 
     return fig, ax
+
+
+def _cost_field_array(
+    grid: FieldGrid,
+    *,
+    log_scale: bool = False,
+    vmax: float | None = None,
+    vmax_percentile: float = 99.0,
+    normalize_range: bool = True,
+) -> tuple[np.ndarray, float, float, str]:
+    """Return display values, vmin, vmax, and colorbar label."""
+    z = np.asarray(grid.Z, dtype=float)
+    label = "log(1 + cost)" if log_scale else "cost"
+    if log_scale:
+        z = np.log1p(np.maximum(z, 0.0))
+    vmin = 0.0
+    if normalize_range:
+        finite = z[np.isfinite(z)]
+        if finite.size:
+            vmin = float(np.min(finite))
+            z = z - vmin
+    if vmax is None:
+        finite = z[np.isfinite(z)]
+        if finite.size:
+            vmax = float(np.percentile(finite, vmax_percentile))
+        else:
+            vmax = 1.0
+    if vmax <= 0.0:
+        vmax = 1.0
+    return z, vmin, vmax, label
+
+
+def cost_field_cmap():
+    """Low cost (blue) to high cost (red) — matplotlib ``turbo``."""
+    import matplotlib.pyplot as plt
+
+    return plt.get_cmap("turbo")
+
+
+def _cost_field_norm(vmax: float, *, gamma: float = 0.55):
+    from matplotlib.colors import PowerNorm
+
+    return PowerNorm(gamma=gamma, vmin=0.0, vmax=vmax)
+
+
+def _resolve_cost_cmap(cmap):
+    return cost_field_cmap() if cmap is None else cmap
+
+
+def _label_cost_colorbar(cbar, vmin, *, normalize_range, log_scale):
+    if normalize_range and log_scale:
+        ticks = cbar.get_ticks()
+        cbar.set_ticks(ticks)
+        cbar.set_ticklabels([f"{t + vmin:.1f}" for t in ticks])
+
+
+def plot_cost_field(
+    grid: FieldGrid,
+    *,
+    ax=None,
+    cmap=None,
+    log_scale: bool = False,
+    vmax: float | None = None,
+    vmax_percentile: float = 99.0,
+    gamma: float = 0.55,
+    normalize_range: bool = True,
+    facecolor: str = "white",
+    colorbar: bool = True,
+    colorbar_label: str | None = None,
+    show: bool = True,
+    figsize=(6.0, 6.0),
+    title: str | None = "Spatial cost",
+    equal_aspect: bool = True,
+):
+    """Plot a workspace cost heatmap. Returns ``(fig, ax)``."""
+    import matplotlib.pyplot as plt
+
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figsize, frameon=True, facecolor=facecolor)
+    else:
+        fig = ax.figure
+
+    z, vmin, vmax, default_label = _cost_field_array(
+        grid,
+        log_scale=log_scale,
+        vmax=vmax,
+        vmax_percentile=vmax_percentile,
+        normalize_range=normalize_range,
+    )
+    cmap_resolved = _resolve_cost_cmap(cmap)
+    norm = _cost_field_norm(vmax, gamma=gamma)
+    ax.set_facecolor(facecolor)
+    image = ax.imshow(
+        z,
+        extent=grid.extent,
+        origin="lower",
+        cmap=cmap_resolved,
+        norm=norm,
+        aspect="auto",
+        zorder=1,
+    )
+    if colorbar:
+        label = colorbar_label if colorbar_label is not None else default_label
+        cbar = fig.colorbar(image, ax=ax, fraction=0.046, pad=0.04, label=label)
+        _label_cost_colorbar(
+            cbar, vmin, normalize_range=normalize_range, log_scale=log_scale
+        )
+    ax.set_xlim(grid.extent[0], grid.extent[1])
+    ax.set_ylim(grid.extent[2], grid.extent[3])
+    if equal_aspect:
+        ax.set_aspect("equal", adjustable="box")
+    ax.set_xlabel("x")
+    ax.set_ylabel("y")
+    ax.set_title(title)
+    ax.grid(True, alpha=0.25, zorder=0)
+
+    if show and plt.get_backend().lower() != "agg":
+        plt.show()
+
+    return fig, ax
+
+
+def plot_cost_field_3d(
+    grid: FieldGrid,
+    *,
+    ax=None,
+    cmap=None,
+    log_scale: bool = False,
+    vmax: float | None = None,
+    vmax_percentile: float = 99.0,
+    gamma: float = 0.55,
+    normalize_range: bool = True,
+    facecolor: str = "white",
+    colorbar: bool = True,
+    colorbar_label: str | None = None,
+    show: bool = True,
+    figsize=(8.0, 6.0),
+    title: str | None = "Spatial cost",
+    elev: float = 35.0,
+    azim: float = -60.0,
+    alpha: float = 0.92,
+    rstride: int = 1,
+    cstride: int = 1,
+):
+    """Plot workspace cost as a 3-D surface ``z = cost(x, y)``. Returns ``(fig, ax)``."""
+    import matplotlib.pyplot as plt
+
+    z, vmin, vmax, default_label = _cost_field_array(
+        grid,
+        log_scale=log_scale,
+        vmax=vmax,
+        vmax_percentile=vmax_percentile,
+        normalize_range=normalize_range,
+    )
+    cmap_resolved = _resolve_cost_cmap(cmap)
+    norm = _cost_field_norm(vmax, gamma=gamma)
+    x_grid, y_grid = np.meshgrid(grid.xs, grid.ys)
+
+    if ax is None:
+        fig = plt.figure(figsize=figsize, frameon=True, facecolor=facecolor)
+        ax = fig.add_subplot(111, projection="3d")
+    else:
+        fig = ax.figure
+
+    ax.set_facecolor(facecolor)
+    surface = ax.plot_surface(
+        x_grid,
+        y_grid,
+        z,
+        cmap=cmap_resolved,
+        norm=norm,
+        linewidth=0.0,
+        antialiased=True,
+        alpha=alpha,
+        rstride=rstride,
+        cstride=cstride,
+    )
+    if colorbar:
+        label = colorbar_label if colorbar_label is not None else default_label
+        cbar = fig.colorbar(surface, ax=ax, shrink=0.62, pad=0.08, label=label)
+        _label_cost_colorbar(
+            cbar, vmin, normalize_range=normalize_range, log_scale=log_scale
+        )
+    ax.set_xlabel("x")
+    ax.set_ylabel("y")
+    ax.set_zlabel(default_label)
+    ax.set_title(title)
+    ax.view_init(elev=elev, azim=azim)
+
+    if show and plt.get_backend().lower() != "agg":
+        plt.show()
+
+    return fig, ax
+
+
+def plot_cost_field_exports(
+    layers,
+    *,
+    track=None,
+    scene=None,
+    overlay_bounds=None,
+    traj=None,
+    log_scale: bool = True,
+    cmap=None,
+    save_dir=None,
+    show: bool = True,
+    figsize_2d=(9.0, 7.0),
+    figsize_3d=(9.0, 7.0),
+    surface_stride: int = 2,
+    **plot_kwargs,
+):
+    """
+    Plot each named cost layer in 2-D and 3-D with the same colormap.
+
+    Parameters
+    ----------
+    layers : dict[str, FieldGrid]
+        e.g. ``{"path": g, "corridor": g, "obstacle": g, "combined": g}``.
+    track, scene
+        Optional overlays drawn on the 2-D figures (``overlay_bounds`` for limits).
+    traj
+        Optional executed path ``(x, y)`` polyline on 2-D figures.
+    save_dir
+        If set, write ``{name}_2d.png`` and ``{name}_3d.png`` for each layer.
+    **plot_kwargs
+        Forwarded to :func:`plot_cost_field` / :func:`plot_cost_field_3d`
+        (``vmax_percentile``, ``gamma``, etc.).
+
+    Returns
+    -------
+    dict
+        ``{name: {"2d": (fig, ax), "3d": (fig, ax)}}``.
+    """
+    from pathlib import Path
+
+    import matplotlib.pyplot as plt
+
+    cmap_resolved = _resolve_cost_cmap(cmap)
+    shared = {"cmap": cmap_resolved, "log_scale": log_scale, **plot_kwargs}
+    out = {}
+    save_path = Path(save_dir) if save_dir is not None else None
+    if save_path is not None:
+        save_path.mkdir(parents=True, exist_ok=True)
+
+    for name, grid in layers.items():
+        title_2d = name.replace("_", " ").title()
+        title_2d_full = f"{title_2d} cost (2D)"
+        title_3d_full = f"{title_2d} cost (3D)"
+        fig2d, ax2d = plot_cost_field(
+            grid,
+            ax=None,
+            title=title_2d_full,
+            show=False,
+            figsize=figsize_2d,
+            **shared,
+        )
+        if track is not None:
+            track.plot(show=False, ax=ax2d, bounds=overlay_bounds, title="")
+        if scene is not None:
+            scene.plot(
+                show=False,
+                ax=ax2d,
+                bounds=overlay_bounds,
+                show_density=False,
+                title="",
+            )
+        if traj is not None:
+            ax2d.plot(
+                traj[0, :],
+                traj[1, :],
+                color="k",
+                linewidth=1.0,
+                alpha=0.85,
+                zorder=7,
+            )
+        ax2d.set_title(title_2d_full)
+        fig2d.tight_layout()
+
+        fig3d, ax3d = plot_cost_field_3d(
+            grid,
+            ax=None,
+            title=title_3d_full,
+            show=False,
+            figsize=figsize_3d,
+            rstride=surface_stride,
+            cstride=surface_stride,
+            **shared,
+        )
+        fig3d.tight_layout()
+
+        if save_path is not None:
+            fig2d.savefig(save_path / f"{name}_2d.png", dpi=160, bbox_inches="tight")
+            fig3d.savefig(save_path / f"{name}_3d.png", dpi=160, bbox_inches="tight")
+
+        out[name] = {"2d": (fig2d, ax2d), "3d": (fig3d, ax3d)}
+
+        if not show:
+            plt.close(fig2d)
+            plt.close(fig3d)
+
+    if show and plt.get_backend().lower() != "agg":
+        plt.show()
+
+    return out
 
 
 def _workspace_dim(scene) -> int:

--- a/tests/unittest/test_spatial.py
+++ b/tests/unittest/test_spatial.py
@@ -18,6 +18,7 @@ from minilink.planning.spatial.collision import (
     disc,
     point_probe,
 )
+from minilink.planning.spatial.grid import sample_field_costs
 from minilink.planning.spatial.scene import Scene
 from minilink.planning.spatial.shaping import (
     inverse_barrier,
@@ -378,3 +379,87 @@ def test_scene_plot_smoke():
 
     _, ax = scene.plot(show=False, body=_holonomic_point(), x=np.array([2.0, 0.0]))
     assert len(ax.lines) >= 1
+
+
+# --- workspace cost raster -------------------------------------------------
+
+
+def test_sample_field_costs_matches_point_probe_cost():
+    scene = Scene(obstacles=(Sphere([2.0, 0.0], 0.5),))
+    body = _holonomic_point()
+    cost = scene.clearance_field(body).as_cost(
+        weight=4.0, shaping=inverse_barrier(epsilon=0.1)
+    )
+    bounds = ((-1.0, 4.0), (-2.0, 2.0))
+    grid = sample_field_costs([cost], bounds=bounds, grid=(5, 4))
+    p = np.array([grid.xs[2], grid.ys[1]])
+    assert grid.Z[1, 2] == pytest.approx(cost.g(p, np.zeros(1)))
+
+
+def test_sample_field_costs_obstacle_is_radially_symmetric():
+    scene = Scene(obstacles=(Sphere([2.0, 0.0], 0.5),))
+    cost = scene.clearance_field(_holonomic_point()).as_cost(weight=1.0)
+    bounds = ((0.0, 4.0), (-2.0, 2.0))
+    grid = sample_field_costs([cost], bounds=bounds, grid=(41, 21))
+    center_j = int(np.argmin(np.abs(grid.ys)))
+    row = grid.Z[center_j, :]
+    xs = grid.xs
+    left = row[xs < 2.0]
+    right = row[xs > 2.0]
+    assert np.allclose(left, right[::-1], rtol=0.0, atol=1e-12)
+
+
+def test_cost_field_cmap_low_to_high_contrast():
+    from minilink.planning.spatial.plotting import cost_field_cmap
+
+    cmap = cost_field_cmap()
+    low = cmap(0.0)
+    high = cmap(1.0)
+    assert low[2] > low[0]  # blue end
+    assert high[0] > high[2]  # red end
+
+
+def test_plot_cost_field_exports_smoke(tmp_path):
+    import os
+
+    os.environ.setdefault("MPLBACKEND", "Agg")
+    import matplotlib
+
+    matplotlib.use("Agg", force=True)
+
+    from minilink.planning.spatial.plotting import plot_cost_field_exports
+
+    scene = Scene(obstacles=(Sphere([1.0, 0.0], 0.4),))
+    body = _holonomic_point()
+    bounds = ((-1.0, 3.0), (-1.0, 1.0))
+    path = scene.clearance_field(body).as_cost(weight=1.0)
+    corridor = scene.clearance_field(body).as_cost(weight=2.0)
+    obstacle = scene.clearance_field(body).as_cost(weight=3.0)
+    grids = {
+        "path": sample_field_costs([path], bounds=bounds, grid=(16, 14)),
+        "corridor": sample_field_costs([corridor], bounds=bounds, grid=(16, 14)),
+        "obstacle": sample_field_costs([obstacle], bounds=bounds, grid=(16, 14)),
+        "combined": sample_field_costs(
+            [path, corridor, obstacle], bounds=bounds, grid=(16, 14)
+        ),
+    }
+    out = plot_cost_field_exports(
+        grids,
+        scene=scene,
+        overlay_bounds=bounds,
+        log_scale=True,
+        show=False,
+        save_dir=tmp_path,
+    )
+    assert set(out) == {"path", "corridor", "obstacle", "combined"}
+    assert out["obstacle"]["2d"][1].get_title() == "Obstacle cost (2D)"
+    assert out["combined"]["3d"][1].get_title() == "Combined cost (3D)"
+    for entry in out.values():
+        fig2d, ax2d = entry["2d"]
+        fig3d, ax3d = entry["3d"]
+        assert fig2d is not None and ax2d is not None
+        assert fig3d is not None and ax3d is not None
+        assert len(fig2d.axes) == 2
+        assert len(fig3d.axes) == 2
+    assert (tmp_path / "combined_2d.png").exists()
+    assert (tmp_path / "combined_3d.png").exists()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Workspace XY cost-field heatmaps and 3D surfaces for MPC tuning.

**Point-probe visualization:** each grid cell evaluates cost at workspace `(x, y)` with `bind(sys, point_probe())`. MPC planner keeps `car_outline`; demo builds separate `*_cost_viz` terms for plots.

## API

- `grid.sample_field_costs`, `grid.pad_bounds`
- `plotting.plot_cost_field`, `plot_cost_field_3d`, `plot_cost_field_exports`

## Layers

`path`, `corridor`, `obstacle`, `combined` — 2D + 3D each.

**Base branch:** `dev-mpc`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1e09-2b3a-78c3-8079-6d34cfe2c445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1e09-2b3a-78c3-8079-6d34cfe2c445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

