### PR TITLE
Add pedagogical MPC spatial scene guide (script + notebook)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -331,6 +331,11 @@ from waypoint polylines via `from_waypoints` (default `kind="polyline"`), wrappe
 clearance (subtract body radius). Compose with obstacles:
 `X = bounds & scene.clearance_field(body).as_constraint() & track.corridor_field(body).as_constraint()`.
 
+**Workspace cost raster** (`grid.sample_field_costs`, `plotting.plot_cost_field` /
+`plot_cost_field_3d` / `plot_cost_field_exports`): rasterize shaped ``FieldCost`` terms
+at workspace points ``p = (x, y)`` with a **point probe** body (heading-independent).
+Build viz costs with ``bind(sys, point_probe())``; MPC may still use ``car_outline``.
+
 **Search / RRT** (`planning/search/`): `RRTPlanner(Planner)` owns the invariant loop and
 sources every concern from the problem — collision `problem.X.contains` (optional
 orchestrator `edge_resolution` densification along edges), goal `problem.Xf`/`x_goal`,

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ NLP:       MathematicalProgram → Optimizer → OptimizationResult
 | Animation | `examples/scripts/animation/` |
 | Optimization | `examples/scripts/optimization/` |
 | Planning (RRT, DP, corridor trajopt) | `examples/scripts/planning/` |
-| MPC (rate-MPC bicycle demos; compile-once `MPCPlanner`; legacy per-step trajopt: `demo_dynamic_bicycle_rate_mpc_straight_line_trajopt.py`; obstacle preset: `demo_dynamic_bicycle_rate_mpc_obstacle.py [small\|large]`) | `examples/scripts/mpc/` |
+| MPC (rate-MPC bicycle demos; compile-once `MPCPlanner`; legacy per-step trajopt: `demo_dynamic_bicycle_rate_mpc_straight_line_trajopt.py`; obstacle preset: `demo_dynamic_bicycle_rate_mpc_obstacle.py [small\|large]`; spatial scene guide: `demo_mpc_spatial_scene_guide.py`) | `examples/scripts/mpc/` · [spatial scene notebook](examples/notebooks/demo_mpc_spatial_scene_guide.ipynb) |
 | Trajectory optimization | `examples/scripts/trajectory_optimization/` |
 | Symbolic mechanics | `examples/scripts/symbolic/` |
 | Physics engine | `examples/scripts/engine/` |

--- a/examples/notebooks/demo_mpc_spatial_scene_guide.ipynb
+++ b/examples/notebooks/demo_mpc_spatial_scene_guide.ipynb
@@ -1,818 +1,978 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# MPC spatial scene guide (waypoints → problem → solve)\n",
-    "\n",
-    "Pedagogical walkthrough for a rate-input dynamic bicycle:\n",
-    "\n",
-    "1. **Workspace** — waypoints, `ReferenceTrack`, sphere obstacles, `Scene` (+ optional terrain).\n",
-    "2. **Body** — `bind(sys, geometry)` turns state `x` into workspace probes.\n",
-    "3. **State fields** — `clearance_field`, `distance_field`, `corridor_field`, `cost_field` expose `value(x)`.\n",
-    "4. **Exports** — `as_constraint()` for hard tubes / free space; `as_cost(shaping=...)` for soft penalties.\n",
-    "5. **Assembly** — `PlanningProblem` with composed `X` and `cost`.\n",
-    "6. **Transcription → NLP** — manual steps: `transcribe` → `MathematicalProgram` → `Optimizer` → `Trajectory`.\n",
-    "7. **Planner wrapper** — `TrajectoryOptimizationPlanner.compute_solution()` orchestrates the same chain.\n",
-    "8. **MPC** — closed-loop receding horizon (last section).\n",
-    "\n",
-    "Companion script (spatial steps only, no solve): `examples/scripts/mpc/demo_mpc_spatial_scene_guide.py`\n",
-    "\n",
-    "Run from repo root with `pip install -e \".[jax]\"`."
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# MPC spatial scene guide (waypoints → problem → solve)\n",
+        "\n",
+        "Pedagogical walkthrough for a rate-input dynamic bicycle:\n",
+        "\n",
+        "1. **Workspace** — waypoints, `ReferenceTrack`, sphere obstacles, `Scene` (+ optional terrain).\n",
+        "2. **Body** — `bind(sys, geometry)` turns state `x` into workspace probes.\n",
+        "3. **State fields** — `clearance_field`, `distance_field`, `corridor_field`, `cost_field` expose `value(x)`.\n",
+        "4. **Exports** — `as_constraint()` for hard tubes / free space; `as_cost(shaping=...)` for soft penalties.\n",
+        "5. **Assembly** — `PlanningProblem` with composed `X` and `cost`.\n",
+        "6. **Transcription → NLP** — manual steps: `transcribe` → `MathematicalProgram` → `Optimizer` → `Trajectory`.\n",
+        "7. **Planner wrapper** — `TrajectoryOptimizationPlanner.compute_solution()` orchestrates the same chain.\n",
+        "8. **MPC** — closed-loop receding horizon (last section).\n",
+        "\n",
+        "Companion script (spatial steps only, no solve): `examples/scripts/mpc/demo_mpc_spatial_scene_guide.py`\n",
+        "\n",
+        "Run from repo root with `pip install -e \".[jax]\"`.\n",
+        "\n",
+        "### Two domains (read this once)\n",
+        "\n",
+        "Spatial planning uses **two coordinates**:\n",
+        "\n",
+        "| Domain | Symbol | Objects | Example query |\n",
+        "| --- | --- | --- | --- |\n",
+        "| **Workspace** | `p ∈ ℝ²` | waypoints, obstacles, terrain | `scene.clearance(p)`, `track.distance(p)` |\n",
+        "| **State** | `x ∈ ℝⁿ` | full vehicle pose + rates | `field.value(x)` after `bind(sys, body)` |\n",
+        "\n",
+        "The bridge is forward kinematics: `bind` places body probes in the workspace from `x`. Costs and constraints are exported on **state**; heatmaps rasterize **workspace** points with `point_probe`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "# %matplotlib inline\n",
+        "\n",
+        "# Colab setup (uncomment):\n",
+        "# !git clone https://github.com/alx87grd/minilink.git\n",
+        "# %cd minilink\n",
+        "# !pip install -q -e \".[jax]\""
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import matplotlib.pyplot as plt\n",
+        "import numpy as np\n",
+        "\n",
+        "from minilink.core.backends import configure_jax\n",
+        "from minilink.core.costs import QuadraticCost\n",
+        "from minilink.core.geometry import Sphere\n",
+        "from minilink.core.sets import BoxSet\n",
+        "from minilink.core.trajectory import Trajectory\n",
+        "from minilink.dynamics.catalog.vehicles.dynamic_bicycle import JaxDynamicBicycleRateInputs\n",
+        "from minilink.graphical.animation.primitives import HorizonPolyline, TrajectoryPolyline\n",
+        "from minilink.graphical.catalog import SceneHistory\n",
+        "from minilink.optimization.evaluators.compiler import compile_program_evaluator\n",
+        "from minilink.optimization.optimizer import Optimizer\n",
+        "from minilink.planning.initial_guess import default_initial_trajectory\n",
+        "from minilink.planning.problems import PlanningProblem\n",
+        "from minilink.planning.spatial.collision import bind, car_outline, point_probe\n",
+        "from minilink.planning.spatial.grid import pad_bounds, sample_field_costs\n",
+        "from minilink.planning.spatial.paths import from_waypoints\n",
+        "from minilink.planning.spatial.plotting import plot_cost_field_exports\n",
+        "from minilink.planning.spatial.scene import Scene\n",
+        "from minilink.planning.spatial.shaping import (\n",
+        "    inverse_barrier,\n",
+        "    occupancy,\n",
+        "    quadratic_excess,\n",
+        "    quadratic_hinge,\n",
+        ")\n",
+        "from minilink.planning.spatial.track import ReferenceTrack\n",
+        "from minilink.planning.spatial.workspace_fields import GaussianField\n",
+        "from minilink.planning.trajectory_optimization.direct_collocation import (\n",
+        "    DirectCollocationOptions,\n",
+        "    DirectCollocationTranscription,\n",
+        ")\n",
+        "from minilink.planning.trajectory_optimization.planner import (\n",
+        "    TrajectoryOptimizationOptions,\n",
+        "    TrajectoryOptimizationPlanner,\n",
+        ")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Scenario parameters\n",
+        "\n",
+        "A compact CCW loop, three keepout spheres, and a soft Gaussian terrain patch."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "WAYPOINTS = np.array(\n",
+        "    [\n",
+        "        [-8.0, -5.0],\n",
+        "        [8.0, -5.0],\n",
+        "        [12.0, 0.0],\n",
+        "        [8.0, 5.0],\n",
+        "        [-8.0, 5.0],\n",
+        "        [-12.0, 0.0],\n",
+        "        [-8.0, -5.0],\n",
+        "    ]\n",
+        ")\n",
+        "CORRIDOR_HALF_WIDTH = 2.0\n",
+        "OBSTACLE_RADIUS = 0.35\n",
+        "OBSTACLE_MARGIN = 0.15\n",
+        "OBSTACLE_CENTERS = ((-4.0, -4.0), (4.0, 0.0), (0.0, 4.0))\n",
+        "TERRAIN_CENTER = (2.0, 2.0)\n",
+        "\n",
+        "PATH_COST_WEIGHT = 30.0\n",
+        "CORRIDOR_COST_WEIGHT = 20.0\n",
+        "OBSTACLE_REPULSION_WEIGHT = 25.0\n",
+        "TERRAIN_COST_WEIGHT = 5.0\n",
+        "U_TARGET = 12.0\n",
+        "\n",
+        "PLOT_MARGIN = 2.0\n",
+        "COST_FIELD_MARGIN = 4.0\n",
+        "PLOT_BOUNDS = (\n",
+        "    (WAYPOINTS[:, 0].min() - PLOT_MARGIN, WAYPOINTS[:, 0].max() + PLOT_MARGIN),\n",
+        "    (WAYPOINTS[:, 1].min() - PLOT_MARGIN, WAYPOINTS[:, 1].max() + PLOT_MARGIN),\n",
+        ")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Map the scenario\n",
+        "\n",
+        "Plot the geometry before attaching a robot — workspace-only objects."
+      ],
+      "id": "150846a8"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "_preview_track = ReferenceTrack(from_waypoints(WAYPOINTS), half_width=CORRIDOR_HALF_WIDTH)\n",
+        "_preview_scene = Scene(\n",
+        "    obstacles=tuple(Sphere(c, OBSTACLE_RADIUS + OBSTACLE_MARGIN) for c in OBSTACLE_CENTERS),\n",
+        "    workspace_fields=(GaussianField(TERRAIN_CENTER, amplitude=1.0, sigma=2.5),),\n",
+        ")\n",
+        "_, ax = _preview_scene.plot(show=False, bounds=PLOT_BOUNDS, show_density=True, title=\"\")\n",
+        "_preview_track.plot(show=False, ax=ax, bounds=PLOT_BOUNDS, title=\"\")\n",
+        "ax.set_title(\"Workspace: track tube + keepouts + terrain\")\n",
+        "plt.show()"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "895cdd12"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 1 — Planner plant\n",
+        "\n",
+        "`JaxDynamicBicycleRateInputs`: wheel speed and steer angle are **states**; their rates are **inputs**."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "configure_jax(enable_x64=True)\n",
+        "\n",
+        "W_REAR_MAX = 90.0\n",
+        "DELTA_MAX = 0.55\n",
+        "W_REAR_DOT_MAX = 80.0\n",
+        "DELTA_DOT_MAX = 2.0\n",
+        "\n",
+        "sys_mpc = JaxDynamicBicycleRateInputs()\n",
+        "sys_mpc.state.lower_bound[6] = 0.0\n",
+        "sys_mpc.state.upper_bound[6] = W_REAR_MAX\n",
+        "sys_mpc.state.lower_bound[7] = -DELTA_MAX\n",
+        "sys_mpc.state.upper_bound[7] = DELTA_MAX\n",
+        "sys_mpc.inputs[\"w_rear_dot\"].lower_bound[0] = -W_REAR_DOT_MAX\n",
+        "sys_mpc.inputs[\"w_rear_dot\"].upper_bound[0] = W_REAR_DOT_MAX\n",
+        "sys_mpc.inputs[\"delta_dot\"].lower_bound[0] = -DELTA_DOT_MAX\n",
+        "sys_mpc.inputs[\"delta_dot\"].upper_bound[0] = DELTA_DOT_MAX\n",
+        "print(f\"n={sys_mpc.n}, m={sys_mpc.m}\")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 2 — Waypoints → `ReferenceTrack`\n",
+        "\n",
+        "`from_waypoints` builds a workspace polyline. `ReferenceTrack` adds a constant half-width corridor.\n",
+        "\n",
+        "Workspace queries (no robot yet):\n",
+        "- `track.distance(p)` — meters to centerline\n",
+        "- `track.corridor_margin(p)` — `half_width - distance` (positive inside the tube)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "track = ReferenceTrack(from_waypoints(WAYPOINTS), half_width=CORRIDOR_HALF_WIDTH)\n",
+        "sample_p = np.array([0.0, -4.0])\n",
+        "print(f\"path length = {track.path.total_length:.2f} m\")\n",
+        "print(f\"distance({sample_p}) = {track.distance(sample_p):.3f}\")\n",
+        "print(f\"corridor_margin({sample_p}) = {track.corridor_margin(sample_p):.3f}\")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 3 — `Scene`: obstacles and terrain\n",
+        "\n",
+        "Hard shapes live in `scene.obstacles`. Soft penalties live in `scene.workspace_fields`.\n",
+        "\n",
+        "Workspace queries:\n",
+        "- `scene.clearance(p)` — signed distance to nearest obstacle (positive in free space)\n",
+        "- `scene.cost_density(p)` — sum of terrain penalty densities\n",
+        "\n",
+        "Factories (need a collision **body** next):\n",
+        "- `scene.clearance_field(body)` → `ClearanceField`\n",
+        "- `scene.cost_field(body)` → `CostDensityField`"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "keepout_radius = OBSTACLE_RADIUS + OBSTACLE_MARGIN\n",
+        "scene = Scene(\n",
+        "    obstacles=tuple(Sphere(c, keepout_radius) for c in OBSTACLE_CENTERS),\n",
+        "    workspace_fields=(GaussianField(TERRAIN_CENTER, amplitude=1.0, sigma=2.5),),\n",
+        ")\n",
+        "print(f\"clearance({sample_p}) = {scene.clearance(sample_p):.3f}\")\n",
+        "print(f\"cost_density({sample_p}) = {scene.cost_density(sample_p):.3f}\")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 4 — Collision body: `bind(sys, geometry)`\n",
+        "\n",
+        "Geometry is **frameless** (`point_probe`, `disc`, `car_outline`). `bind` attaches it to the planner plant so forward kinematics place probes in the workspace — the same transform used for rendering.\n",
+        "\n",
+        "- **MPC planner** — `car_outline` (oriented footprint)\n",
+        "- **Heatmaps** — `point_probe` (workspace position only, heading-independent)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "body = bind(sys_mpc, car_outline(length=2.2, width=0.2, margin=0.05))\n",
+        "probe = bind(sys_mpc, point_probe())\n",
+        "\n",
+        "r_r = sys_mpc.params[\"r_r\"]\n",
+        "w_rear_ref = U_TARGET / r_r\n",
+        "x_cruise = np.array([0.0, -4.0, 0.0, U_TARGET, 0.0, 0.0, w_rear_ref, 0.0])\n",
+        "ubar = np.zeros(sys_mpc.m)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Probe vs body at the same pose\n",
+        "\n",
+        "`car_outline` subtracts footprint extent; `point_probe` is a single world point. Heatmaps use `point_probe` so tuning plots do not depend on heading."
+      ],
+      "id": "42179414"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "_clear_body = scene.clearance_field(body).value(x_cruise)\n",
+        "_clear_probe = scene.clearance_field(probe).value(x_cruise)\n",
+        "print(f\"clearance @ x_cruise  car_outline = {_clear_body:.3f} m\")\n",
+        "print(f\"clearance @ x_cruise  point_probe = {_clear_probe:.3f} m\")\n",
+        "print(f\"delta (body more conservative) = {_clear_probe - _clear_body:.3f} m\")"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "7f9188bf"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 5 — State fields: `value(x)`\n",
+        "\n",
+        "Each field fuses workspace queries over all body probes (min clearance / distance, max terrain density).\n",
+        "\n",
+        "Track factories mirror the scene pattern:\n",
+        "- `track.distance_field(body)` → `PathDistanceField`\n",
+        "- `track.corridor_field(body)` → `CorridorMarginField`"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "clearance_field = scene.clearance_field(body)\n",
+        "corridor_field = track.corridor_field(body)\n",
+        "distance_field = track.distance_field(body)\n",
+        "terrain_field = scene.cost_field(body)\n",
+        "\n",
+        "for name, field in [\n",
+        "    (\"clearance\", clearance_field),\n",
+        "    (\"corridor\", corridor_field),\n",
+        "    (\"path distance\", distance_field),\n",
+        "    (\"terrain\", terrain_field),\n",
+        "]:\n",
+        "    print(f\"{name:14s} value(x_cruise) = {float(field.value(x_cruise)):.4f}\")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 6 — Hard set: `field.as_constraint()`\n",
+        "\n",
+        "`FieldSet` is feasible where `lower <= value(x) <= upper`. Compose with `&`:\n",
+        "\n",
+        "```\n",
+        "X = state_bounds & obstacle_free & corridor_tube\n",
+        "```\n",
+        "\n",
+        "Direct collocation enforces `X.contains(x_k)` at each node. MPC demos often skip hard `X` and rely on soft costs only; both patterns are shown here."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Hard vs soft — when to use which\n",
+        "\n",
+        "| Export | Feasibility | Typical use |\n",
+        "| --- | --- | --- |\n",
+        "| `as_constraint(lower=0)` | **Must** satisfy at every collocation node | corridor tube, collision-free band |\n",
+        "| `as_cost(shaping=...)` | Penalty only — solver may trade off | path centering, obstacle repulsion, comfort |\n",
+        "\n",
+        "This notebook uses **both**: hard `X` for the tube and obstacles, soft costs for tracking and barriers. Many MPC demos drop hard spatial `X` and rely on weighted soft costs only — easier to tune, no guaranteed feasibility."
+      ],
+      "id": "a5668fc9"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "X = (\n",
+        "    BoxSet.from_system_state(sys_mpc)\n",
+        "    & clearance_field.as_constraint(lower=0.0)\n",
+        "    & corridor_field.as_constraint(lower=0.0)\n",
+        ")\n",
+        "print(\"X assembled: bounds ∩ obstacle clearance ≥ 0 ∩ corridor margin ≥ 0\")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 7 — Soft cost: `field.as_cost(shaping=...)`\n",
+        "\n",
+        "Shaping maps the raw field value to a penalty **before** weighting:\n",
+        "\n",
+        "| Shaping | Use with | Effect |\n",
+        "| --- | --- | --- |\n",
+        "| `quadratic_excess` | path distance | quadratic once farther than threshold from centerline |\n",
+        "| `quadratic_hinge` | corridor margin | quadratic once outside the tube |\n",
+        "| `inverse_barrier` | clearance | blows up as clearance → 0 |\n",
+        "| `occupancy` | terrain density | bounded sigmoid in [0, 1] |\n",
+        "\n",
+        "Compose with `+` on `CostFunction` terms."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "stability_cost = QuadraticCost.from_system(\n",
+        "    sys_mpc,\n",
+        "    Q=np.diag([0.0, 0.0, 0.0, 0.15, 4.0, 6.0, 0.1, 80.0]),\n",
+        "    R=np.diag([1.0, 22.0]),\n",
+        "    S=np.diag([0.0, 0.0, 0.0, 0.15, 4.0, 6.0, 0.1, 80.0]),\n",
+        "    xbar=x_cruise,\n",
+        "    ubar=ubar,\n",
+        ")\n",
+        "path_cost = distance_field.as_cost(\n",
+        "    weight=PATH_COST_WEIGHT, shaping=quadratic_excess(threshold=0.1)\n",
+        ")\n",
+        "corridor_cost = corridor_field.as_cost(\n",
+        "    weight=CORRIDOR_COST_WEIGHT, shaping=quadratic_hinge(threshold=0.0)\n",
+        ")\n",
+        "obstacle_cost = clearance_field.as_cost(\n",
+        "    weight=OBSTACLE_REPULSION_WEIGHT, shaping=inverse_barrier(epsilon=0.08)\n",
+        ")\n",
+        "terrain_cost = terrain_field.as_cost(\n",
+        "    weight=TERRAIN_COST_WEIGHT, shaping=occupancy(scale=1.0)\n",
+        ")\n",
+        "cost = stability_cost + path_cost + corridor_cost + obstacle_cost + terrain_cost"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "_v = np.linspace(-0.5, 3.0, 200)\n",
+        "fig, ax = plt.subplots(figsize=(7.0, 3.5))\n",
+        "ax.plot(_v, [float(quadratic_excess(0.1)(vi)) for vi in _v], label=\"quadratic_excess (path)\")\n",
+        "ax.plot(_v, [float(quadratic_hinge(0.0)(vi)) for vi in _v], label=\"quadratic_hinge (corridor)\")\n",
+        "ax.plot(_v, [float(inverse_barrier(0.08)(vi)) for vi in _v], label=\"inverse_barrier (obstacle)\")\n",
+        "ax.plot(_v, [float(occupancy(1.0)(vi)) for vi in _v], label=\"occupancy (terrain)\")\n",
+        "ax.set_xlabel(\"raw field value v\")\n",
+        "ax.set_ylabel(\"shaping(v)\")\n",
+        "ax.set_title(\"Shaping functions (before weighting)\")\n",
+        "ax.legend(fontsize=8)\n",
+        "ax.grid(True, alpha=0.3)\n",
+        "plt.tight_layout()\n",
+        "plt.show()"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "7b43e8c3"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 8 — `PlanningProblem`\n",
+        "\n",
+        "The **continuous** object passed to transcription. Receding-horizon MPC rebuilds it each tick with the measured `x_start`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "problem = PlanningProblem(sys=sys_mpc, x_start=x_cruise, X=X, cost=cost)\n",
+        "print(problem)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 9 — Transcription: continuous → finite NLP\n",
+        "\n",
+        "Architecture contract (see `DESIGN.md`):\n",
+        "\n",
+        "```\n",
+        "PlanningProblem  →  Transcription.transcribe()  →  MathematicalProgram\n",
+        "                                                      ↓\n",
+        "pack_initial_guess → z0  →  Optimizer.solve()  →  OptimizationResult\n",
+        "                                                      ↓\n",
+        "                              reconstruct_result()  →  Trajectory\n",
+        "```\n",
+        "\n",
+        "**Direct collocation** picks a fixed time grid `t[0], …, t[N-1]` and packs all sampled states and inputs into one decision vector:\n",
+        "\n",
+        "```\n",
+        "z = [x[0,:], …, x[n-1,:], u[0,:], …, u[m-1,:]]   # shape (n_z,)\n",
+        "```\n",
+        "\n",
+        "The `MathematicalProgram` is the textbook NLP\n",
+        "\n",
+        "```\n",
+        "minimize   J(z)\n",
+        "subject to h(z) = 0        # trapezoidal dynamics defects + boundary equalities\n",
+        "           g(z) ≥ 0        # path/corridor/obstacle margins from problem.X\n",
+        "           lower ≤ z ≤ upper\n",
+        "```\n",
+        "\n",
+        "`MathematicalProgram` stores only these callables — no solver state. `Optimizer` compiles gradients/Jacobians and calls SciPy (or IPOPT)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "MPC_HORIZON = 2.0\n",
+        "MPC_STEPS = 20\n",
+        "MPC_MAXITER = 120\n",
+        "MPC_FTOL = 1e-1\n",
+        "COMPILE_BACKEND = \"jax\"\n",
+        "\n",
+        "transcription = DirectCollocationTranscription(\n",
+        "    DirectCollocationOptions(tf=MPC_HORIZON, n_steps=MPC_STEPS)\n",
+        ")\n",
+        "trajopt_options = TrajectoryOptimizationOptions(\n",
+        "    compile_backend=COMPILE_BACKEND,\n",
+        "    optimizer_method=\"scipy_slsqp\",\n",
+        "    solve_disp=False,\n",
+        "    record_solve_time=True,\n",
+        "    optimizer_options={\"maxiter\": MPC_MAXITER, \"ftol\": MPC_FTOL},\n",
+        ")\n",
+        "n, m, n_steps = sys_mpc.n, sys_mpc.m, MPC_STEPS\n",
+        "print(f\"horizon={MPC_HORIZON}s, N={n_steps} nodes\")\n",
+        "print(f\"decision dim n_z = (n + m) * N = ({n} + {m}) * {n_steps} = {(n + m) * n_steps}\")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Step 9a — `transcribe(problem)` → `MathematicalProgram`\n",
+        "\n",
+        "The transcription reads `problem.cost`, `problem.X`, `problem.X0`/`Xf`, and `problem.sys.f`, then builds `J`, `h`, `g`, and box bounds on `z`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "program = transcription.transcribe(problem, compile_backend=COMPILE_BACKEND)\n",
+        "evaluator = compile_program_evaluator(program, sample_z=np.zeros(program.n_z))\n",
+        "print(\"MathematicalProgram\")\n",
+        "print(f\"  n_z   = {program.n_z}\")\n",
+        "print(f\"  n_h   = {evaluator.n_h}  (equalities: dynamics defects + boundaries)\")\n",
+        "print(f\"  n_g   = {evaluator.n_g}  (inequalities: path/corridor/obstacle margins)\")\n",
+        "print(f\"  backend = {program.backend!r}\")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Step 9b — Initial guess on the collocation grid\n",
+        "\n",
+        "`initial_guess_time_grid` returns `t = linspace(0, tf, N)`. `default_initial_trajectory` interpolates from `x_start` toward `x_goal` (or holds `x_start` when no goal). `pack_initial_guess` flattens `(x, u)` into `z0`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "t_grid = transcription.initial_guess_time_grid(problem)\n",
+        "guess = default_initial_trajectory(problem, t_grid)\n",
+        "z0 = transcription.pack_initial_guess(problem, guess)\n",
+        "\n",
+        "evaluator = compile_program_evaluator(program, sample_z=z0)\n",
+        "J0 = float(evaluator.objective(z0))\n",
+        "max_eq, min_ineq, max_bound = evaluator.constraint_violations(z0)\n",
+        "print(f\"t_grid: {t_grid[0]:.2f} … {t_grid[-1]:.2f} s  ({t_grid.size} nodes)\")\n",
+        "print(f\"z0 shape = {z0.shape}\")\n",
+        "print(f\"J(z0) = {J0:.4f}\")\n",
+        "print(f\"violations @ z0: max_eq={max_eq:.2e}, min_ineq={min_ineq:.2e}, max_bound={max_bound:.2e}\")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "**Reading constraint violations**\n",
+        "\n",
+        "- `max_eq` — largest |equality residual|; should be ≈ 0 when dynamics and pinned `x_start` are satisfied.\n",
+        "- `min_ineq` — smallest inequality margin `g(z)`; should be ≥ 0 when corridor/obstacle constraints are feasible.\n",
+        "- `max_bound` — box-bound slack violation on `z`.\n",
+        "\n",
+        "Decode `z0` to confirm the first collocation state matches `x_start`:"
+      ],
+      "id": "6d6d0121"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "x0_unpack, u0_unpack = transcription.unpack(z0, problem)\n",
+        "print(\"x[:, 0] from z0:\", np.round(x0_unpack[:, 0], 3))\n",
+        "print(\"x_start:       \", np.round(problem.x_start, 3))\n",
+        "print(\"match:\", np.allclose(x0_unpack[:, 0], problem.x_start, atol=1e-9))"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "12b91264"
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Step 9c — `Optimizer(program, z0).solve()` → `OptimizationResult`\n",
+        "\n",
+        "`Optimizer` compiles `J`, `h`, `g` (and derivatives) into a backend evaluator, then dispatches to the requested solver method."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "optimizer = Optimizer(\n",
+        "    program,\n",
+        "    z0=z0,\n",
+        "    method=trajopt_options.optimizer_method,\n",
+        "    use_hessian=trajopt_options.use_hessian,\n",
+        "    options=dict(trajopt_options.optimizer_options),\n",
+        ")\n",
+        "manual_result = optimizer.solve(record_solve_time=True)\n",
+        "\n",
+        "max_eq, min_ineq, max_bound = optimizer.program_evaluator.constraint_violations(\n",
+        "    manual_result.z\n",
+        ")\n",
+        "print(f\"success = {manual_result.success}\")\n",
+        "print(f\"message = {manual_result.message}\")\n",
+        "print(f\"J* = {manual_result.cost:.4f}\")\n",
+        "print(f\"solve_time = {manual_result.solve_time_s:.3f} s\")\n",
+        "print(f\"violations @ z*: max_eq={max_eq:.2e}, min_ineq={min_ineq:.2e}, max_bound={max_bound:.2e}\")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Step 9d — `reconstruct_result` → `Trajectory`\n",
+        "\n",
+        "Unpack `z*` back into `(x, u)` matrices on the collocation grid and attach `dx` (and per-node cost if available)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "manual_traj = transcription.reconstruct_result(\n",
+        "    manual_result,\n",
+        "    problem=problem,\n",
+        "    compile_backend=COMPILE_BACKEND,\n",
+        ")\n",
+        "print(f\"trajectory: {manual_traj.n_samples} samples, tf={manual_traj.t[-1]:.2f} s\")\n",
+        "print(f\"x(0)  xy = ({manual_traj.x[0,0]:.2f}, {manual_traj.x[1,0]:.2f})\")\n",
+        "print(f\"x(tf) xy = ({manual_traj.x[0,-1]:.2f}, {manual_traj.x[1,-1]:.2f})\")\n",
+        "\n",
+        "_, ax = scene.plot(show=False, bounds=PLOT_BOUNDS, show_density=False, title=\"\")\n",
+        "track.plot(show=False, ax=ax, bounds=PLOT_BOUNDS, title=\"\")\n",
+        "ax.plot(manual_traj.x[0, :], manual_traj.x[1, :], \"c--\", linewidth=1.2, label=\"manual solve\")\n",
+        "ax.legend(loc=\"upper left\")\n",
+        "ax.set_title(\"Single-horizon plan (manual pipeline)\")\n",
+        "plt.show()"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 10 — `TrajectoryOptimizationPlanner` wraps the same chain\n",
+        "\n",
+        "`compute_solution()` is exactly steps 9a–9d orchestrated:\n",
+        "\n",
+        "| Manual | Planner method |\n",
+        "| --- | --- |\n",
+        "| resolve initial guess | `_resolve_initial_guess()` |\n",
+        "| `transcription.transcribe()` | same |\n",
+        "| `pack_initial_guess()` | same |\n",
+        "| `Optimizer(...)` | `_make_optimizer()` |\n",
+        "| `optimizer.solve()` | same |\n",
+        "| `reconstruct_result()` | same |\n",
+        "\n",
+        "The planner also caches `last_program`, `last_optimizer`, and `last_optimization_result` for inspection."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "planner = TrajectoryOptimizationPlanner(\n",
+        "    problem,\n",
+        "    transcription=transcription,\n",
+        "    options=trajopt_options,\n",
+        ")\n",
+        "planner_traj = planner.compute_solution(initial_guess=guess)\n",
+        "wrapper_result = planner.last_optimization_result\n",
+        "\n",
+        "print(\"Planner wrapper vs manual pipeline:\")\n",
+        "print(f\"  n_z match: {planner.last_program.n_z == program.n_z}\")\n",
+        "print(f\"  J* manual  = {manual_result.cost:.6f}\")\n",
+        "print(f\"  J* planner = {wrapper_result.cost:.6f}\")\n",
+        "print(f\"  xy close: {np.allclose(planner_traj.x[0:2], manual_traj.x[0:2], atol=1e-3)}\")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Step 11 — Workspace cost heatmaps\n",
+        "\n",
+        "`sample_field_costs` evaluates each grid cell as a **workspace point** with `point_probe` costs (heading-independent). Use these plots to **tune weights** before or after running MPC — they show what the optimizer \"sees\" in XY, not a guarantee of the executed path."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "path_cost_viz = track.distance_field(probe).as_cost(\n",
+        "    weight=PATH_COST_WEIGHT, shaping=quadratic_excess(threshold=0.1)\n",
+        ")\n",
+        "corridor_cost_viz = track.corridor_field(probe).as_cost(\n",
+        "    weight=CORRIDOR_COST_WEIGHT, shaping=quadratic_hinge(threshold=0.0)\n",
+        ")\n",
+        "obstacle_cost_viz = scene.clearance_field(probe).as_cost(\n",
+        "    weight=OBSTACLE_REPULSION_WEIGHT, shaping=inverse_barrier(epsilon=0.08)\n",
+        ")\n",
+        "cost_bounds = pad_bounds(PLOT_BOUNDS, COST_FIELD_MARGIN - PLOT_MARGIN)\n",
+        "_cost_kw = dict(bounds=cost_bounds, state_dim=sys_mpc.n, grid=(100, 100))\n",
+        "layers = {\n",
+        "    \"path\": sample_field_costs([path_cost_viz], **_cost_kw),\n",
+        "    \"corridor\": sample_field_costs([corridor_cost_viz], **_cost_kw),\n",
+        "    \"obstacle\": sample_field_costs([obstacle_cost_viz], **_cost_kw),\n",
+        "    \"combined\": sample_field_costs(\n",
+        "        [path_cost_viz, corridor_cost_viz, obstacle_cost_viz], **_cost_kw\n",
+        "    ),\n",
+        "}\n",
+        "\n",
+        "_, ax = scene.plot(show=False, bounds=PLOT_BOUNDS, show_density=True, title=\"\")\n",
+        "track.plot(show=False, ax=ax, bounds=PLOT_BOUNDS, title=\"\")\n",
+        "ax.set_title(\"Scene + reference track\")\n",
+        "plt.show()\n",
+        "\n",
+        "plot_cost_field_exports(\n",
+        "    layers,\n",
+        "    track=track,\n",
+        "    scene=scene,\n",
+        "    overlay_bounds=PLOT_BOUNDS,\n",
+        "    log_scale=True,\n",
+        ")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "\n",
+        "## MPC closed loop\n",
+        "\n",
+        "Receding horizon: every `MPC_DT` seconds, measure `x`, solve a **new** `PlanningProblem` over `[t, t + MPC_HORIZON]`, apply only `u(:,0)`, integrate the plant until the next tick.\n",
+        "\n",
+        "```\n",
+        "t=0        solve ──► apply u₀ ──► simulate ──► t=Δt\n",
+        "t=Δt       solve ──► apply u₀ ──► simulate ──► t=2Δt\n",
+        "           (warm-start guess from shifted previous plan)\n",
+        "```\n",
+        "\n",
+        "Each tick uses `TrajectoryOptimizationPlanner` — the wrapper from Step 10."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "TF_SIM = 8.0\n",
+        "VX0 = 8.0\n",
+        "MPC_HZ = 5.0\n",
+        "SIM_HZ = 200.0\n",
+        "MPC_DT = 1.0 / MPC_HZ\n",
+        "SIM_DT = 1.0 / SIM_HZ\n",
+        "SUBSTEPS = max(1, int(round(MPC_DT / SIM_DT)))\n",
+        "\n",
+        "sys_sim = JaxDynamicBicycleRateInputs()\n",
+        "sys_sim.params[\"mass\"] = 1.03 * sys_mpc.params[\"mass\"]\n",
+        "sys_sim.params[\"inertia\"] = 1.02 * sys_mpc.params[\"inertia\"]\n",
+        "for sys in (sys_mpc, sys_sim):\n",
+        "    sys.state.lower_bound[6] = 0.0\n",
+        "    sys.state.upper_bound[6] = W_REAR_MAX\n",
+        "    sys.state.lower_bound[7] = -DELTA_MAX\n",
+        "    sys.state.upper_bound[7] = DELTA_MAX\n",
+        "    sys.inputs[\"w_rear_dot\"].lower_bound[0] = -W_REAR_DOT_MAX\n",
+        "    sys.inputs[\"w_rear_dot\"].upper_bound[0] = W_REAR_DOT_MAX\n",
+        "    sys.inputs[\"delta_dot\"].lower_bound[0] = -DELTA_DOT_MAX\n",
+        "    sys.inputs[\"delta_dot\"].upper_bound[0] = DELTA_DOT_MAX\n",
+        "\n",
+        "s_start, _ = track.path.project(WAYPOINTS[0])\n",
+        "tangent = track.path.tangent(s_start)\n",
+        "theta0 = float(np.arctan2(tangent[1], tangent[0]))\n",
+        "x0 = np.array(\n",
+        "    [WAYPOINTS[0, 0], WAYPOINTS[0, 1], theta0, VX0, 0.0, 0.0, VX0 / r_r, 0.0]\n",
+        ")\n",
+        "sim_evaluator = sys_sim.compile(backend=\"jax\", verbose=False)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "t_hist = [0.0]\n",
+        "x_hist = [x0.copy()]\n",
+        "u_hist = [np.zeros(sys_sim.m)]\n",
+        "mpc_plans = []\n",
+        "x = x0.copy()\n",
+        "t = 0.0\n",
+        "u_hold = np.zeros(sys_sim.m)\n",
+        "prev_plan = None\n",
+        "next_mpc_t = 0.0\n",
+        "\n",
+        "while t < TF_SIM - 1e-12:\n",
+        "    if t >= next_mpc_t - 1e-12:\n",
+        "        tick_problem = PlanningProblem(sys=sys_mpc, x_start=x, X=X, cost=cost)\n",
+        "        tick_planner = TrajectoryOptimizationPlanner(\n",
+        "            tick_problem,\n",
+        "            transcription=transcription,\n",
+        "            options=trajopt_options,\n",
+        "        )\n",
+        "        guess = None\n",
+        "        if prev_plan is not None and prev_plan.n_samples >= 3:\n",
+        "            t_shift = prev_plan.t + MPC_DT\n",
+        "            mask = t_shift <= t + MPC_HORIZON + 1e-9\n",
+        "            if np.count_nonzero(mask) >= 3:\n",
+        "                x_guess = prev_plan.x[:, mask].copy()\n",
+        "                x_guess[:, 0] = x\n",
+        "                guess = Trajectory(\n",
+        "                    t=t_shift[mask] - t,\n",
+        "                    x=x_guess,\n",
+        "                    u=prev_plan.u[:, mask],\n",
+        "                )\n",
+        "        else:\n",
+        "            guess = default_initial_trajectory(\n",
+        "                tick_problem,\n",
+        "                transcription.initial_guess_time_grid(tick_problem),\n",
+        "            )\n",
+        "        plan = tick_planner.compute_solution(initial_guess=guess)\n",
+        "        res = tick_planner.last_optimization_result\n",
+        "        print(\n",
+        "            f\"MPC @ t={t:.2f}s  success={res.success}  solve={res.solve_time_s:.3f}s\"\n",
+        "        )\n",
+        "        prev_plan = plan\n",
+        "        u_hold = plan.u[:, 0].copy()\n",
+        "        mpc_plans.append(\n",
+        "            (t, Trajectory(t=plan.t + t, x=plan.x.copy(), u=plan.u.copy()))\n",
+        "        )\n",
+        "        next_mpc_t += MPC_DT\n",
+        "\n",
+        "    for _ in range(SUBSTEPS):\n",
+        "        if t >= TF_SIM:\n",
+        "            break\n",
+        "        x = sim_evaluator.rk4_step(x, u_hold, t, SIM_DT)\n",
+        "        t += SIM_DT\n",
+        "        t_hist.append(t)\n",
+        "        x_hist.append(x.copy())\n",
+        "        u_hist.append(u_hold.copy())\n",
+        "\n",
+        "traj = Trajectory(\n",
+        "    t=np.asarray(t_hist), x=np.asarray(x_hist).T, u=np.asarray(u_hist).T\n",
+        ")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Results\n",
+        "\n",
+        "Executed path on the scene, then state/input histories."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "_, ax = scene.plot(\n",
+        "    show=False,\n",
+        "    bounds=PLOT_BOUNDS,\n",
+        "    title=\"MPC on spatial scene\",\n",
+        "    show_density=False,\n",
+        ")\n",
+        "track.plot(show=False, ax=ax, bounds=PLOT_BOUNDS, title=\"\")\n",
+        "ax.plot(traj.x[0, :], traj.x[1, :], color=\"tab:blue\", linewidth=1.5, label=\"executed\")\n",
+        "ax.legend(loc=\"upper left\")\n",
+        "plt.show()\n",
+        "\n",
+        "sys_sim.params = dict(sys_sim.params)\n",
+        "sys_sim.camera_scale = 14.0\n",
+        "sys_sim.traj = traj\n",
+        "sys_sim.plot_trajectory(signals=(\"x\", \"u\"))"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "history = SceneHistory(\n",
+        "    trail=TrajectoryPolyline(traj, window=\"prefix\", color=\"b\", style=\"--\", linewidth=1.0),\n",
+        "    horizon=HorizonPolyline(mpc_plans, color=\"tab:orange\", linewidth=2.0, style=\"--\"),\n",
+        ")\n",
+        "sys_sim.animate(traj, overlays=[scene.as_visualizer(color=\"tab:red\", opacity=0.45), history])"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "\n",
+        "## Recap and extensions\n",
+        "\n",
+        "**Pipeline in one line:** workspace geometry → state fields → `PlanningProblem` → transcribe → optimize → `Trajectory` → MPC loop.\n",
+        "\n",
+        "| Next step | Where |\n",
+        "| --- | --- |\n",
+        "| Holonomic corridor trajopt (hard tube + goal) | `examples/scripts/trajectory_optimization/demo_holonomic_corridor.py` |\n",
+        "| Scene-only obstacle slalom MPC | `examples/scripts/mpc/demo_dynamic_bicycle_rate_mpc_multi_obstacle_scene.py` |\n",
+        "| Wide circuit + cost heatmaps | `examples/scripts/mpc/demo_dynamic_bicycle_rate_mpc_wide_circuit_lap.py` |\n",
+        "| Architecture contracts | `DESIGN.md` §6 (optimization/planning), spatial scene section |\n",
+        "\n",
+        "**Try it (optional)**\n",
+        "\n",
+        "1. Set `trajopt_options.solve_disp=True` and re-run Step 10 — full NLP preamble/report.\n",
+        "2. Remove hard `X` (keep soft costs only) and compare solve time / constraint violations.\n",
+        "3. Change one cost weight, re-run Step 11 heatmaps, then MPC — see how repulsion vs path tracking trades off."
+      ],
+      "id": "5a630e3f"
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.10.0"
+    }
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# %matplotlib inline\n",
-    "\n",
-    "# Colab setup (uncomment):\n",
-    "# !git clone https://github.com/alx87grd/minilink.git\n",
-    "# %cd minilink\n",
-    "# !pip install -q -e \".[jax]\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import matplotlib.pyplot as plt\n",
-    "import numpy as np\n",
-    "\n",
-    "from minilink.core.backends import configure_jax\n",
-    "from minilink.core.costs import QuadraticCost\n",
-    "from minilink.core.geometry import Sphere\n",
-    "from minilink.core.sets import BoxSet\n",
-    "from minilink.core.trajectory import Trajectory\n",
-    "from minilink.dynamics.catalog.vehicles.dynamic_bicycle import JaxDynamicBicycleRateInputs\n",
-    "from minilink.graphical.animation.primitives import HorizonPolyline, TrajectoryPolyline\n",
-    "from minilink.graphical.catalog import SceneHistory\n",
-    "from minilink.optimization.evaluators.compiler import compile_program_evaluator\n",
-    "from minilink.optimization.optimizer import Optimizer\n",
-    "from minilink.planning.initial_guess import default_initial_trajectory\n",
-    "from minilink.planning.problems import PlanningProblem\n",
-    "from minilink.planning.spatial.collision import bind, car_outline, point_probe\n",
-    "from minilink.planning.spatial.grid import pad_bounds, sample_field_costs\n",
-    "from minilink.planning.spatial.paths import from_waypoints\n",
-    "from minilink.planning.spatial.plotting import plot_cost_field_exports\n",
-    "from minilink.planning.spatial.scene import Scene\n",
-    "from minilink.planning.spatial.shaping import (\n",
-    "    inverse_barrier,\n",
-    "    occupancy,\n",
-    "    quadratic_excess,\n",
-    "    quadratic_hinge,\n",
-    ")\n",
-    "from minilink.planning.spatial.track import ReferenceTrack\n",
-    "from minilink.planning.spatial.workspace_fields import GaussianField\n",
-    "from minilink.planning.trajectory_optimization.direct_collocation import (\n",
-    "    DirectCollocationOptions,\n",
-    "    DirectCollocationTranscription,\n",
-    ")\n",
-    "from minilink.planning.trajectory_optimization.planner import (\n",
-    "    TrajectoryOptimizationOptions,\n",
-    "    TrajectoryOptimizationPlanner,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Scenario parameters\n",
-    "\n",
-    "A compact CCW loop, three keepout spheres, and a soft Gaussian terrain patch."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "WAYPOINTS = np.array(\n",
-    "    [\n",
-    "        [-8.0, -5.0],\n",
-    "        [8.0, -5.0],\n",
-    "        [12.0, 0.0],\n",
-    "        [8.0, 5.0],\n",
-    "        [-8.0, 5.0],\n",
-    "        [-12.0, 0.0],\n",
-    "        [-8.0, -5.0],\n",
-    "    ]\n",
-    ")\n",
-    "CORRIDOR_HALF_WIDTH = 2.0\n",
-    "OBSTACLE_RADIUS = 0.35\n",
-    "OBSTACLE_MARGIN = 0.15\n",
-    "OBSTACLE_CENTERS = ((-4.0, -4.0), (4.0, 0.0), (0.0, 4.0))\n",
-    "TERRAIN_CENTER = (2.0, 2.0)\n",
-    "\n",
-    "PATH_COST_WEIGHT = 30.0\n",
-    "CORRIDOR_COST_WEIGHT = 20.0\n",
-    "OBSTACLE_REPULSION_WEIGHT = 25.0\n",
-    "TERRAIN_COST_WEIGHT = 5.0\n",
-    "U_TARGET = 12.0\n",
-    "\n",
-    "PLOT_MARGIN = 2.0\n",
-    "COST_FIELD_MARGIN = 4.0\n",
-    "PLOT_BOUNDS = (\n",
-    "    (WAYPOINTS[:, 0].min() - PLOT_MARGIN, WAYPOINTS[:, 0].max() + PLOT_MARGIN),\n",
-    "    (WAYPOINTS[:, 1].min() - PLOT_MARGIN, WAYPOINTS[:, 1].max() + PLOT_MARGIN),\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Step 1 — Planner plant\n",
-    "\n",
-    "`JaxDynamicBicycleRateInputs`: wheel speed and steer angle are **states**; their rates are **inputs**."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "configure_jax(enable_x64=True)\n",
-    "\n",
-    "W_REAR_MAX = 90.0\n",
-    "DELTA_MAX = 0.55\n",
-    "W_REAR_DOT_MAX = 80.0\n",
-    "DELTA_DOT_MAX = 2.0\n",
-    "\n",
-    "sys_mpc = JaxDynamicBicycleRateInputs()\n",
-    "sys_mpc.state.lower_bound[6] = 0.0\n",
-    "sys_mpc.state.upper_bound[6] = W_REAR_MAX\n",
-    "sys_mpc.state.lower_bound[7] = -DELTA_MAX\n",
-    "sys_mpc.state.upper_bound[7] = DELTA_MAX\n",
-    "sys_mpc.inputs[\"w_rear_dot\"].lower_bound[0] = -W_REAR_DOT_MAX\n",
-    "sys_mpc.inputs[\"w_rear_dot\"].upper_bound[0] = W_REAR_DOT_MAX\n",
-    "sys_mpc.inputs[\"delta_dot\"].lower_bound[0] = -DELTA_DOT_MAX\n",
-    "sys_mpc.inputs[\"delta_dot\"].upper_bound[0] = DELTA_DOT_MAX\n",
-    "print(f\"n={sys_mpc.n}, m={sys_mpc.m}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Step 2 — Waypoints → `ReferenceTrack`\n",
-    "\n",
-    "`from_waypoints` builds a workspace polyline. `ReferenceTrack` adds a constant half-width corridor.\n",
-    "\n",
-    "Workspace queries (no robot yet):\n",
-    "- `track.distance(p)` — meters to centerline\n",
-    "- `track.corridor_margin(p)` — `half_width - distance` (positive inside the tube)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "track = ReferenceTrack(from_waypoints(WAYPOINTS), half_width=CORRIDOR_HALF_WIDTH)\n",
-    "sample_p = np.array([0.0, -4.0])\n",
-    "print(f\"path length = {track.path.total_length:.2f} m\")\n",
-    "print(f\"distance({sample_p}) = {track.distance(sample_p):.3f}\")\n",
-    "print(f\"corridor_margin({sample_p}) = {track.corridor_margin(sample_p):.3f}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Step 3 — `Scene`: obstacles and terrain\n",
-    "\n",
-    "Hard shapes live in `scene.obstacles`. Soft penalties live in `scene.workspace_fields`.\n",
-    "\n",
-    "Workspace queries:\n",
-    "- `scene.clearance(p)` — signed distance to nearest obstacle (positive in free space)\n",
-    "- `scene.cost_density(p)` — sum of terrain penalty densities\n",
-    "\n",
-    "Factories (need a collision **body** next):\n",
-    "- `scene.clearance_field(body)` → `ClearanceField`\n",
-    "- `scene.cost_field(body)` → `CostDensityField`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "keepout_radius = OBSTACLE_RADIUS + OBSTACLE_MARGIN\n",
-    "scene = Scene(\n",
-    "    obstacles=tuple(Sphere(c, keepout_radius) for c in OBSTACLE_CENTERS),\n",
-    "    workspace_fields=(GaussianField(TERRAIN_CENTER, amplitude=1.0, sigma=2.5),),\n",
-    ")\n",
-    "print(f\"clearance({sample_p}) = {scene.clearance(sample_p):.3f}\")\n",
-    "print(f\"cost_density({sample_p}) = {scene.cost_density(sample_p):.3f}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Step 4 — Collision body: `bind(sys, geometry)`\n",
-    "\n",
-    "Geometry is **frameless** (`point_probe`, `disc`, `car_outline`). `bind` attaches it to the planner plant so forward kinematics place probes in the workspace — the same transform used for rendering.\n",
-    "\n",
-    "- **MPC planner** — `car_outline` (oriented footprint)\n",
-    "- **Heatmaps** — `point_probe` (workspace position only, heading-independent)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "body = bind(sys_mpc, car_outline(length=2.2, width=0.2, margin=0.05))\n",
-    "probe = bind(sys_mpc, point_probe())\n",
-    "\n",
-    "r_r = sys_mpc.params[\"r_r\"]\n",
-    "w_rear_ref = U_TARGET / r_r\n",
-    "x_cruise = np.array([0.0, -4.0, 0.0, U_TARGET, 0.0, 0.0, w_rear_ref, 0.0])\n",
-    "ubar = np.zeros(sys_mpc.m)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Step 5 — State fields: `value(x)`\n",
-    "\n",
-    "Each field fuses workspace queries over all body probes (min clearance / distance, max terrain density).\n",
-    "\n",
-    "Track factories mirror the scene pattern:\n",
-    "- `track.distance_field(body)` → `PathDistanceField`\n",
-    "- `track.corridor_field(body)` → `CorridorMarginField`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "clearance_field = scene.clearance_field(body)\n",
-    "corridor_field = track.corridor_field(body)\n",
-    "distance_field = track.distance_field(body)\n",
-    "terrain_field = scene.cost_field(body)\n",
-    "\n",
-    "for name, field in [\n",
-    "    (\"clearance\", clearance_field),\n",
-    "    (\"corridor\", corridor_field),\n",
-    "    (\"path distance\", distance_field),\n",
-    "    (\"terrain\", terrain_field),\n",
-    "]:\n",
-    "    print(f\"{name:14s} value(x_cruise) = {float(field.value(x_cruise)):.4f}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Step 6 — Hard set: `field.as_constraint()`\n",
-    "\n",
-    "`FieldSet` is feasible where `lower <= value(x) <= upper`. Compose with `&`:\n",
-    "\n",
-    "```\n",
-    "X = state_bounds & obstacle_free & corridor_tube\n",
-    "```\n",
-    "\n",
-    "Direct collocation enforces `X.contains(x_k)` at each node. MPC demos often skip hard `X` and rely on soft costs only; both patterns are shown here."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "X = (\n",
-    "    BoxSet.from_system_state(sys_mpc)\n",
-    "    & clearance_field.as_constraint(lower=0.0)\n",
-    "    & corridor_field.as_constraint(lower=0.0)\n",
-    ")\n",
-    "print(\"X assembled: bounds ∩ obstacle clearance ≥ 0 ∩ corridor margin ≥ 0\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Step 7 — Soft cost: `field.as_cost(shaping=...)`\n",
-    "\n",
-    "Shaping maps the raw field value to a penalty **before** weighting:\n",
-    "\n",
-    "| Shaping | Use with | Effect |\n",
-    "| --- | --- | --- |\n",
-    "| `quadratic_excess` | path distance | quadratic once farther than threshold from centerline |\n",
-    "| `quadratic_hinge` | corridor margin | quadratic once outside the tube |\n",
-    "| `inverse_barrier` | clearance | blows up as clearance → 0 |\n",
-    "| `occupancy` | terrain density | bounded sigmoid in [0, 1] |\n",
-    "\n",
-    "Compose with `+` on `CostFunction` terms."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "stability_cost = QuadraticCost.from_system(\n",
-    "    sys_mpc,\n",
-    "    Q=np.diag([0.0, 0.0, 0.0, 0.15, 4.0, 6.0, 0.1, 80.0]),\n",
-    "    R=np.diag([1.0, 22.0]),\n",
-    "    S=np.diag([0.0, 0.0, 0.0, 0.15, 4.0, 6.0, 0.1, 80.0]),\n",
-    "    xbar=x_cruise,\n",
-    "    ubar=ubar,\n",
-    ")\n",
-    "path_cost = distance_field.as_cost(\n",
-    "    weight=PATH_COST_WEIGHT, shaping=quadratic_excess(threshold=0.1)\n",
-    ")\n",
-    "corridor_cost = corridor_field.as_cost(\n",
-    "    weight=CORRIDOR_COST_WEIGHT, shaping=quadratic_hinge(threshold=0.0)\n",
-    ")\n",
-    "obstacle_cost = clearance_field.as_cost(\n",
-    "    weight=OBSTACLE_REPULSION_WEIGHT, shaping=inverse_barrier(epsilon=0.08)\n",
-    ")\n",
-    "terrain_cost = terrain_field.as_cost(\n",
-    "    weight=TERRAIN_COST_WEIGHT, shaping=occupancy(scale=1.0)\n",
-    ")\n",
-    "cost = stability_cost + path_cost + corridor_cost + obstacle_cost + terrain_cost"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Step 8 — `PlanningProblem`\n",
-    "\n",
-    "The **continuous** object passed to transcription. Receding-horizon MPC rebuilds it each tick with the measured `x_start`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "problem = PlanningProblem(sys=sys_mpc, x_start=x_cruise, X=X, cost=cost)\n",
-    "print(problem)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Step 9 — Transcription: continuous → finite NLP\n",
-    "\n",
-    "Architecture contract (see `DESIGN.md`):\n",
-    "\n",
-    "```\n",
-    "PlanningProblem  →  Transcription.transcribe()  →  MathematicalProgram\n",
-    "                                                      ↓\n",
-    "pack_initial_guess → z0  →  Optimizer.solve()  →  OptimizationResult\n",
-    "                                                      ↓\n",
-    "                              reconstruct_result()  →  Trajectory\n",
-    "```\n",
-    "\n",
-    "**Direct collocation** picks a fixed time grid `t[0], …, t[N-1]` and packs all sampled states and inputs into one decision vector:\n",
-    "\n",
-    "```\n",
-    "z = [x[0,:], …, x[n-1,:], u[0,:], …, u[m-1,:]]   # shape (n_z,)\n",
-    "```\n",
-    "\n",
-    "The `MathematicalProgram` is the textbook NLP\n",
-    "\n",
-    "```\n",
-    "minimize   J(z)\n",
-    "subject to h(z) = 0        # trapezoidal dynamics defects + boundary equalities\n",
-    "           g(z) ≥ 0        # path/corridor/obstacle margins from problem.X\n",
-    "           lower ≤ z ≤ upper\n",
-    "```\n",
-    "\n",
-    "`MathematicalProgram` stores only these callables — no solver state. `Optimizer` compiles gradients/Jacobians and calls SciPy (or IPOPT)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "MPC_HORIZON = 2.0\n",
-    "MPC_STEPS = 20\n",
-    "MPC_MAXITER = 120\n",
-    "MPC_FTOL = 1e-1\n",
-    "COMPILE_BACKEND = \"jax\"\n",
-    "\n",
-    "transcription = DirectCollocationTranscription(\n",
-    "    DirectCollocationOptions(tf=MPC_HORIZON, n_steps=MPC_STEPS)\n",
-    ")\n",
-    "trajopt_options = TrajectoryOptimizationOptions(\n",
-    "    compile_backend=COMPILE_BACKEND,\n",
-    "    optimizer_method=\"scipy_slsqp\",\n",
-    "    solve_disp=False,\n",
-    "    record_solve_time=True,\n",
-    "    optimizer_options={\"maxiter\": MPC_MAXITER, \"ftol\": MPC_FTOL},\n",
-    ")\n",
-    "n, m, n_steps = sys_mpc.n, sys_mpc.m, MPC_STEPS\n",
-    "print(f\"horizon={MPC_HORIZON}s, N={n_steps} nodes\")\n",
-    "print(f\"decision dim n_z = (n + m) * N = ({n} + {m}) * {n_steps} = {(n + m) * n_steps}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Step 9a — `transcribe(problem)` → `MathematicalProgram`\n",
-    "\n",
-    "The transcription reads `problem.cost`, `problem.X`, `problem.X0`/`Xf`, and `problem.sys.f`, then builds `J`, `h`, `g`, and box bounds on `z`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "program = transcription.transcribe(problem, compile_backend=COMPILE_BACKEND)\n",
-    "evaluator = compile_program_evaluator(program, sample_z=np.zeros(program.n_z))\n",
-    "print(\"MathematicalProgram\")\n",
-    "print(f\"  n_z   = {program.n_z}\")\n",
-    "print(f\"  n_h   = {evaluator.n_h}  (equalities: dynamics defects + boundaries)\")\n",
-    "print(f\"  n_g   = {evaluator.n_g}  (inequalities: path/corridor/obstacle margins)\")\n",
-    "print(f\"  backend = {program.backend!r}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Step 9b — Initial guess on the collocation grid\n",
-    "\n",
-    "`initial_guess_time_grid` returns `t = linspace(0, tf, N)`. `default_initial_trajectory` interpolates from `x_start` toward `x_goal` (or holds `x_start` when no goal). `pack_initial_guess` flattens `(x, u)` into `z0`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "t_grid = transcription.initial_guess_time_grid(problem)\n",
-    "guess = default_initial_trajectory(problem, t_grid)\n",
-    "z0 = transcription.pack_initial_guess(problem, guess)\n",
-    "\n",
-    "evaluator = compile_program_evaluator(program, sample_z=z0)\n",
-    "J0 = float(evaluator.objective(z0))\n",
-    "max_eq, min_ineq, max_bound = evaluator.constraint_violations(z0)\n",
-    "print(f\"t_grid: {t_grid[0]:.2f} … {t_grid[-1]:.2f} s  ({t_grid.size} nodes)\")\n",
-    "print(f\"z0 shape = {z0.shape}\")\n",
-    "print(f\"J(z0) = {J0:.4f}\")\n",
-    "print(f\"violations @ z0: max_eq={max_eq:.2e}, min_ineq={min_ineq:.2e}, max_bound={max_bound:.2e}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Step 9c — `Optimizer(program, z0).solve()` → `OptimizationResult`\n",
-    "\n",
-    "`Optimizer` compiles `J`, `h`, `g` (and derivatives) into a backend evaluator, then dispatches to the requested solver method."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "optimizer = Optimizer(\n",
-    "    program,\n",
-    "    z0=z0,\n",
-    "    method=trajopt_options.optimizer_method,\n",
-    "    use_hessian=trajopt_options.use_hessian,\n",
-    "    options=dict(trajopt_options.optimizer_options),\n",
-    ")\n",
-    "manual_result = optimizer.solve(record_solve_time=True)\n",
-    "\n",
-    "max_eq, min_ineq, max_bound = optimizer.program_evaluator.constraint_violations(\n",
-    "    manual_result.z\n",
-    ")\n",
-    "print(f\"success = {manual_result.success}\")\n",
-    "print(f\"message = {manual_result.message}\")\n",
-    "print(f\"J* = {manual_result.cost:.4f}\")\n",
-    "print(f\"solve_time = {manual_result.solve_time_s:.3f} s\")\n",
-    "print(f\"violations @ z*: max_eq={max_eq:.2e}, min_ineq={min_ineq:.2e}, max_bound={max_bound:.2e}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Step 9d — `reconstruct_result` → `Trajectory`\n",
-    "\n",
-    "Unpack `z*` back into `(x, u)` matrices on the collocation grid and attach `dx` (and per-node cost if available)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "manual_traj = transcription.reconstruct_result(\n",
-    "    manual_result,\n",
-    "    problem=problem,\n",
-    "    compile_backend=COMPILE_BACKEND,\n",
-    ")\n",
-    "print(f\"trajectory: {manual_traj.n_samples} samples, tf={manual_traj.t[-1]:.2f} s\")\n",
-    "print(f\"x(0)  xy = ({manual_traj.x[0,0]:.2f}, {manual_traj.x[1,0]:.2f})\")\n",
-    "print(f\"x(tf) xy = ({manual_traj.x[0,-1]:.2f}, {manual_traj.x[1,-1]:.2f})\")\n",
-    "\n",
-    "_, ax = scene.plot(show=False, bounds=PLOT_BOUNDS, show_density=False, title=\"\")\n",
-    "track.plot(show=False, ax=ax, bounds=PLOT_BOUNDS, title=\"\")\n",
-    "ax.plot(manual_traj.x[0, :], manual_traj.x[1, :], \"c--\", linewidth=1.2, label=\"manual solve\")\n",
-    "ax.legend(loc=\"upper left\")\n",
-    "ax.set_title(\"Single-horizon plan (manual pipeline)\")\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Step 10 — `TrajectoryOptimizationPlanner` wraps the same chain\n",
-    "\n",
-    "`compute_solution()` is exactly steps 9a–9d orchestrated:\n",
-    "\n",
-    "| Manual | Planner method |\n",
-    "| --- | --- |\n",
-    "| resolve initial guess | `_resolve_initial_guess()` |\n",
-    "| `transcription.transcribe()` | same |\n",
-    "| `pack_initial_guess()` | same |\n",
-    "| `Optimizer(...)` | `_make_optimizer()` |\n",
-    "| `optimizer.solve()` | same |\n",
-    "| `reconstruct_result()` | same |\n",
-    "\n",
-    "The planner also caches `last_program`, `last_optimizer`, and `last_optimization_result` for inspection."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "planner = TrajectoryOptimizationPlanner(\n",
-    "    problem,\n",
-    "    transcription=transcription,\n",
-    "    options=trajopt_options,\n",
-    ")\n",
-    "planner_traj = planner.compute_solution(initial_guess=guess)\n",
-    "wrapper_result = planner.last_optimization_result\n",
-    "\n",
-    "print(\"Planner wrapper vs manual pipeline:\")\n",
-    "print(f\"  n_z match: {planner.last_program.n_z == program.n_z}\")\n",
-    "print(f\"  J* manual  = {manual_result.cost:.6f}\")\n",
-    "print(f\"  J* planner = {wrapper_result.cost:.6f}\")\n",
-    "print(f\"  xy close: {np.allclose(planner_traj.x[0:2], manual_traj.x[0:2], atol=1e-3)}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Step 11 — Workspace cost heatmaps\n",
-    "\n",
-    "`sample_field_costs` evaluates each grid cell as a **workspace point** with `point_probe` costs (heading-independent tuning view)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "path_cost_viz = track.distance_field(probe).as_cost(\n",
-    "    weight=PATH_COST_WEIGHT, shaping=quadratic_excess(threshold=0.1)\n",
-    ")\n",
-    "corridor_cost_viz = track.corridor_field(probe).as_cost(\n",
-    "    weight=CORRIDOR_COST_WEIGHT, shaping=quadratic_hinge(threshold=0.0)\n",
-    ")\n",
-    "obstacle_cost_viz = scene.clearance_field(probe).as_cost(\n",
-    "    weight=OBSTACLE_REPULSION_WEIGHT, shaping=inverse_barrier(epsilon=0.08)\n",
-    ")\n",
-    "cost_bounds = pad_bounds(PLOT_BOUNDS, COST_FIELD_MARGIN - PLOT_MARGIN)\n",
-    "_cost_kw = dict(bounds=cost_bounds, state_dim=sys_mpc.n, grid=(100, 100))\n",
-    "layers = {\n",
-    "    \"path\": sample_field_costs([path_cost_viz], **_cost_kw),\n",
-    "    \"corridor\": sample_field_costs([corridor_cost_viz], **_cost_kw),\n",
-    "    \"obstacle\": sample_field_costs([obstacle_cost_viz], **_cost_kw),\n",
-    "    \"combined\": sample_field_costs(\n",
-    "        [path_cost_viz, corridor_cost_viz, obstacle_cost_viz], **_cost_kw\n",
-    "    ),\n",
-    "}\n",
-    "\n",
-    "_, ax = scene.plot(show=False, bounds=PLOT_BOUNDS, show_density=True, title=\"\")\n",
-    "track.plot(show=False, ax=ax, bounds=PLOT_BOUNDS, title=\"\")\n",
-    "ax.set_title(\"Scene + reference track\")\n",
-    "plt.show()\n",
-    "\n",
-    "plot_cost_field_exports(\n",
-    "    layers,\n",
-    "    track=track,\n",
-    "    scene=scene,\n",
-    "    overlay_bounds=PLOT_BOUNDS,\n",
-    "    log_scale=True,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "---\n",
-    "\n",
-    "## MPC closed loop\n",
-    "\n",
-    "Each tick: rebuild `PlanningProblem` with measured `x`, call `planner.compute_solution()` (the wrapper above), hold the first planned input, integrate the plant."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "TF_SIM = 8.0\n",
-    "VX0 = 8.0\n",
-    "MPC_HZ = 5.0\n",
-    "SIM_HZ = 200.0\n",
-    "MPC_DT = 1.0 / MPC_HZ\n",
-    "SIM_DT = 1.0 / SIM_HZ\n",
-    "SUBSTEPS = max(1, int(round(MPC_DT / SIM_DT)))\n",
-    "\n",
-    "sys_sim = JaxDynamicBicycleRateInputs()\n",
-    "sys_sim.params[\"mass\"] = 1.03 * sys_mpc.params[\"mass\"]\n",
-    "sys_sim.params[\"inertia\"] = 1.02 * sys_mpc.params[\"inertia\"]\n",
-    "for sys in (sys_mpc, sys_sim):\n",
-    "    sys.state.lower_bound[6] = 0.0\n",
-    "    sys.state.upper_bound[6] = W_REAR_MAX\n",
-    "    sys.state.lower_bound[7] = -DELTA_MAX\n",
-    "    sys.state.upper_bound[7] = DELTA_MAX\n",
-    "    sys.inputs[\"w_rear_dot\"].lower_bound[0] = -W_REAR_DOT_MAX\n",
-    "    sys.inputs[\"w_rear_dot\"].upper_bound[0] = W_REAR_DOT_MAX\n",
-    "    sys.inputs[\"delta_dot\"].lower_bound[0] = -DELTA_DOT_MAX\n",
-    "    sys.inputs[\"delta_dot\"].upper_bound[0] = DELTA_DOT_MAX\n",
-    "\n",
-    "s_start, _ = track.path.project(WAYPOINTS[0])\n",
-    "tangent = track.path.tangent(s_start)\n",
-    "theta0 = float(np.arctan2(tangent[1], tangent[0]))\n",
-    "x0 = np.array(\n",
-    "    [WAYPOINTS[0, 0], WAYPOINTS[0, 1], theta0, VX0, 0.0, 0.0, VX0 / r_r, 0.0]\n",
-    ")\n",
-    "sim_evaluator = sys_sim.compile(backend=\"jax\", verbose=False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "t_hist = [0.0]\n",
-    "x_hist = [x0.copy()]\n",
-    "u_hist = [np.zeros(sys_sim.m)]\n",
-    "mpc_plans = []\n",
-    "x = x0.copy()\n",
-    "t = 0.0\n",
-    "u_hold = np.zeros(sys_sim.m)\n",
-    "prev_plan = None\n",
-    "next_mpc_t = 0.0\n",
-    "\n",
-    "while t < TF_SIM - 1e-12:\n",
-    "    if t >= next_mpc_t - 1e-12:\n",
-    "        tick_problem = PlanningProblem(sys=sys_mpc, x_start=x, X=X, cost=cost)\n",
-    "        tick_planner = TrajectoryOptimizationPlanner(\n",
-    "            tick_problem,\n",
-    "            transcription=transcription,\n",
-    "            options=trajopt_options,\n",
-    "        )\n",
-    "        guess = None\n",
-    "        if prev_plan is not None and prev_plan.n_samples >= 3:\n",
-    "            t_shift = prev_plan.t + MPC_DT\n",
-    "            mask = t_shift <= t + MPC_HORIZON + 1e-9\n",
-    "            if np.count_nonzero(mask) >= 3:\n",
-    "                x_guess = prev_plan.x[:, mask].copy()\n",
-    "                x_guess[:, 0] = x\n",
-    "                guess = Trajectory(\n",
-    "                    t=t_shift[mask] - t,\n",
-    "                    x=x_guess,\n",
-    "                    u=prev_plan.u[:, mask],\n",
-    "                )\n",
-    "        else:\n",
-    "            guess = default_initial_trajectory(\n",
-    "                tick_problem,\n",
-    "                transcription.initial_guess_time_grid(tick_problem),\n",
-    "            )\n",
-    "        plan = tick_planner.compute_solution(initial_guess=guess)\n",
-    "        res = tick_planner.last_optimization_result\n",
-    "        print(\n",
-    "            f\"MPC @ t={t:.2f}s  success={res.success}  solve={res.solve_time_s:.3f}s\"\n",
-    "        )\n",
-    "        prev_plan = plan\n",
-    "        u_hold = plan.u[:, 0].copy()\n",
-    "        mpc_plans.append(\n",
-    "            (t, Trajectory(t=plan.t + t, x=plan.x.copy(), u=plan.u.copy()))\n",
-    "        )\n",
-    "        next_mpc_t += MPC_DT\n",
-    "\n",
-    "    for _ in range(SUBSTEPS):\n",
-    "        if t >= TF_SIM:\n",
-    "            break\n",
-    "        x = sim_evaluator.rk4_step(x, u_hold, t, SIM_DT)\n",
-    "        t += SIM_DT\n",
-    "        t_hist.append(t)\n",
-    "        x_hist.append(x.copy())\n",
-    "        u_hist.append(u_hold.copy())\n",
-    "\n",
-    "traj = Trajectory(\n",
-    "    t=np.asarray(t_hist), x=np.asarray(x_hist).T, u=np.asarray(u_hist).T\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Results\n",
-    "\n",
-    "Executed path on the scene, then state/input histories."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "_, ax = scene.plot(\n",
-    "    show=False,\n",
-    "    bounds=PLOT_BOUNDS,\n",
-    "    title=\"MPC on spatial scene\",\n",
-    "    show_density=False,\n",
-    ")\n",
-    "track.plot(show=False, ax=ax, bounds=PLOT_BOUNDS, title=\"\")\n",
-    "ax.plot(traj.x[0, :], traj.x[1, :], color=\"tab:blue\", linewidth=1.5, label=\"executed\")\n",
-    "ax.legend(loc=\"upper left\")\n",
-    "plt.show()\n",
-    "\n",
-    "sys_sim.params = dict(sys_sim.params)\n",
-    "sys_sim.camera_scale = 14.0\n",
-    "sys_sim.traj = traj\n",
-    "sys_sim.plot_trajectory(signals=(\"x\", \"u\"))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "history = SceneHistory(\n",
-    "    trail=TrajectoryPolyline(traj, window=\"prefix\", color=\"b\", style=\"--\", linewidth=1.0),\n",
-    "    horizon=HorizonPolyline(mpc_plans, color=\"tab:orange\", linewidth=2.0, style=\"--\"),\n",
-    ")\n",
-    "sys_sim.animate(traj, overlays=[scene.as_visualizer(color=\"tab:red\", opacity=0.45), history])"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "name": "python",
-   "version": "3.10.0"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/examples/notebooks/demo_mpc_spatial_scene_guide.ipynb
+++ b/examples/notebooks/demo_mpc_spatial_scene_guide.ipynb
@@ -6,16 +6,18 @@
    "source": [
     "# MPC spatial scene guide (waypoints → problem → solve)\n",
     "\n",
-    "Pedagogical walkthrough of the `planning/spatial` pipeline for a rate-input dynamic bicycle:\n",
+    "Pedagogical walkthrough for a rate-input dynamic bicycle:\n",
     "\n",
     "1. **Workspace** — waypoints, `ReferenceTrack`, sphere obstacles, `Scene` (+ optional terrain).\n",
     "2. **Body** — `bind(sys, geometry)` turns state `x` into workspace probes.\n",
     "3. **State fields** — `clearance_field`, `distance_field`, `corridor_field`, `cost_field` expose `value(x)`.\n",
     "4. **Exports** — `as_constraint()` for hard tubes / free space; `as_cost(shaping=...)` for soft penalties.\n",
-    "5. **Assembly** — compose `X` and `cost`, build `PlanningProblem`, wire direct collocation.\n",
-    "6. **MPC** — closed-loop receding horizon (last section).\n",
+    "5. **Assembly** — `PlanningProblem` with composed `X` and `cost`.\n",
+    "6. **Transcription → NLP** — manual steps: `transcribe` → `MathematicalProgram` → `Optimizer` → `Trajectory`.\n",
+    "7. **Planner wrapper** — `TrajectoryOptimizationPlanner.compute_solution()` orchestrates the same chain.\n",
+    "8. **MPC** — closed-loop receding horizon (last section).\n",
     "\n",
-    "Companion script (no solve): `examples/scripts/mpc/demo_mpc_spatial_scene_guide.py`\n",
+    "Companion script (spatial steps only, no solve): `examples/scripts/mpc/demo_mpc_spatial_scene_guide.py`\n",
     "\n",
     "Run from repo root with `pip install -e \".[jax]\"`."
    ]
@@ -51,6 +53,8 @@
     "from minilink.dynamics.catalog.vehicles.dynamic_bicycle import JaxDynamicBicycleRateInputs\n",
     "from minilink.graphical.animation.primitives import HorizonPolyline, TrajectoryPolyline\n",
     "from minilink.graphical.catalog import SceneHistory\n",
+    "from minilink.optimization.evaluators.compiler import compile_program_evaluator\n",
+    "from minilink.optimization.optimizer import Optimizer\n",
     "from minilink.planning.initial_guess import default_initial_trajectory\n",
     "from minilink.planning.problems import PlanningProblem\n",
     "from minilink.planning.spatial.collision import bind, car_outline, point_probe\n",
@@ -356,7 +360,7 @@
    "source": [
     "## Step 8 — `PlanningProblem`\n",
     "\n",
-    "Receding-horizon MPC rebuilds `PlanningProblem(sys, x_start=x, cost=cost)` each tick with the measured state."
+    "The **continuous** object passed to transcription. Receding-horizon MPC rebuilds it each tick with the measured `x_start`."
    ]
   },
   {
@@ -373,9 +377,34 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Step 9 — Direct collocation planner (preview)\n",
+    "## Step 9 — Transcription: continuous → finite NLP\n",
     "\n",
-    "Transcription discretizes the horizon; `TrajectoryOptimizationPlanner` compiles and solves the NLP. The MPC section below calls `compute_solution` in a loop."
+    "Architecture contract (see `DESIGN.md`):\n",
+    "\n",
+    "```\n",
+    "PlanningProblem  →  Transcription.transcribe()  →  MathematicalProgram\n",
+    "                                                      ↓\n",
+    "pack_initial_guess → z0  →  Optimizer.solve()  →  OptimizationResult\n",
+    "                                                      ↓\n",
+    "                              reconstruct_result()  →  Trajectory\n",
+    "```\n",
+    "\n",
+    "**Direct collocation** picks a fixed time grid `t[0], …, t[N-1]` and packs all sampled states and inputs into one decision vector:\n",
+    "\n",
+    "```\n",
+    "z = [x[0,:], …, x[n-1,:], u[0,:], …, u[m-1,:]]   # shape (n_z,)\n",
+    "```\n",
+    "\n",
+    "The `MathematicalProgram` is the textbook NLP\n",
+    "\n",
+    "```\n",
+    "minimize   J(z)\n",
+    "subject to h(z) = 0        # trapezoidal dynamics defects + boundary equalities\n",
+    "           g(z) ≥ 0        # path/corridor/obstacle margins from problem.X\n",
+    "           lower ≤ z ≤ upper\n",
+    "```\n",
+    "\n",
+    "`MathematicalProgram` stores only these callables — no solver state. `Optimizer` compiles gradients/Jacobians and calls SciPy (or IPOPT)."
    ]
   },
   {
@@ -388,25 +417,187 @@
     "MPC_STEPS = 20\n",
     "MPC_MAXITER = 120\n",
     "MPC_FTOL = 1e-1\n",
+    "COMPILE_BACKEND = \"jax\"\n",
     "\n",
     "transcription = DirectCollocationTranscription(\n",
     "    DirectCollocationOptions(tf=MPC_HORIZON, n_steps=MPC_STEPS)\n",
     ")\n",
     "trajopt_options = TrajectoryOptimizationOptions(\n",
-    "    compile_backend=\"jax\",\n",
+    "    compile_backend=COMPILE_BACKEND,\n",
     "    optimizer_method=\"scipy_slsqp\",\n",
     "    solve_disp=False,\n",
     "    record_solve_time=True,\n",
     "    optimizer_options={\"maxiter\": MPC_MAXITER, \"ftol\": MPC_FTOL},\n",
     ")\n",
-    "print(f\"horizon {MPC_HORIZON}s, {MPC_STEPS} collocation nodes\")"
+    "n, m, n_steps = sys_mpc.n, sys_mpc.m, MPC_STEPS\n",
+    "print(f\"horizon={MPC_HORIZON}s, N={n_steps} nodes\")\n",
+    "print(f\"decision dim n_z = (n + m) * N = ({n} + {m}) * {n_steps} = {(n + m) * n_steps}\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Step 10 — Workspace cost heatmaps\n",
+    "### Step 9a — `transcribe(problem)` → `MathematicalProgram`\n",
+    "\n",
+    "The transcription reads `problem.cost`, `problem.X`, `problem.X0`/`Xf`, and `problem.sys.f`, then builds `J`, `h`, `g`, and box bounds on `z`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "program = transcription.transcribe(problem, compile_backend=COMPILE_BACKEND)\n",
+    "evaluator = compile_program_evaluator(program, sample_z=np.zeros(program.n_z))\n",
+    "print(\"MathematicalProgram\")\n",
+    "print(f\"  n_z   = {program.n_z}\")\n",
+    "print(f\"  n_h   = {evaluator.n_h}  (equalities: dynamics defects + boundaries)\")\n",
+    "print(f\"  n_g   = {evaluator.n_g}  (inequalities: path/corridor/obstacle margins)\")\n",
+    "print(f\"  backend = {program.backend!r}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Step 9b — Initial guess on the collocation grid\n",
+    "\n",
+    "`initial_guess_time_grid` returns `t = linspace(0, tf, N)`. `default_initial_trajectory` interpolates from `x_start` toward `x_goal` (or holds `x_start` when no goal). `pack_initial_guess` flattens `(x, u)` into `z0`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "t_grid = transcription.initial_guess_time_grid(problem)\n",
+    "guess = default_initial_trajectory(problem, t_grid)\n",
+    "z0 = transcription.pack_initial_guess(problem, guess)\n",
+    "\n",
+    "evaluator = compile_program_evaluator(program, sample_z=z0)\n",
+    "J0 = float(evaluator.objective(z0))\n",
+    "max_eq, min_ineq, max_bound = evaluator.constraint_violations(z0)\n",
+    "print(f\"t_grid: {t_grid[0]:.2f} … {t_grid[-1]:.2f} s  ({t_grid.size} nodes)\")\n",
+    "print(f\"z0 shape = {z0.shape}\")\n",
+    "print(f\"J(z0) = {J0:.4f}\")\n",
+    "print(f\"violations @ z0: max_eq={max_eq:.2e}, min_ineq={min_ineq:.2e}, max_bound={max_bound:.2e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Step 9c — `Optimizer(program, z0).solve()` → `OptimizationResult`\n",
+    "\n",
+    "`Optimizer` compiles `J`, `h`, `g` (and derivatives) into a backend evaluator, then dispatches to the requested solver method."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optimizer = Optimizer(\n",
+    "    program,\n",
+    "    z0=z0,\n",
+    "    method=trajopt_options.optimizer_method,\n",
+    "    use_hessian=trajopt_options.use_hessian,\n",
+    "    options=dict(trajopt_options.optimizer_options),\n",
+    ")\n",
+    "manual_result = optimizer.solve(record_solve_time=True)\n",
+    "\n",
+    "max_eq, min_ineq, max_bound = optimizer.program_evaluator.constraint_violations(\n",
+    "    manual_result.z\n",
+    ")\n",
+    "print(f\"success = {manual_result.success}\")\n",
+    "print(f\"message = {manual_result.message}\")\n",
+    "print(f\"J* = {manual_result.cost:.4f}\")\n",
+    "print(f\"solve_time = {manual_result.solve_time_s:.3f} s\")\n",
+    "print(f\"violations @ z*: max_eq={max_eq:.2e}, min_ineq={min_ineq:.2e}, max_bound={max_bound:.2e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Step 9d — `reconstruct_result` → `Trajectory`\n",
+    "\n",
+    "Unpack `z*` back into `(x, u)` matrices on the collocation grid and attach `dx` (and per-node cost if available)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "manual_traj = transcription.reconstruct_result(\n",
+    "    manual_result,\n",
+    "    problem=problem,\n",
+    "    compile_backend=COMPILE_BACKEND,\n",
+    ")\n",
+    "print(f\"trajectory: {manual_traj.n_samples} samples, tf={manual_traj.t[-1]:.2f} s\")\n",
+    "print(f\"x(0)  xy = ({manual_traj.x[0,0]:.2f}, {manual_traj.x[1,0]:.2f})\")\n",
+    "print(f\"x(tf) xy = ({manual_traj.x[0,-1]:.2f}, {manual_traj.x[1,-1]:.2f})\")\n",
+    "\n",
+    "_, ax = scene.plot(show=False, bounds=PLOT_BOUNDS, show_density=False, title=\"\")\n",
+    "track.plot(show=False, ax=ax, bounds=PLOT_BOUNDS, title=\"\")\n",
+    "ax.plot(manual_traj.x[0, :], manual_traj.x[1, :], \"c--\", linewidth=1.2, label=\"manual solve\")\n",
+    "ax.legend(loc=\"upper left\")\n",
+    "ax.set_title(\"Single-horizon plan (manual pipeline)\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 10 — `TrajectoryOptimizationPlanner` wraps the same chain\n",
+    "\n",
+    "`compute_solution()` is exactly steps 9a–9d orchestrated:\n",
+    "\n",
+    "| Manual | Planner method |\n",
+    "| --- | --- |\n",
+    "| resolve initial guess | `_resolve_initial_guess()` |\n",
+    "| `transcription.transcribe()` | same |\n",
+    "| `pack_initial_guess()` | same |\n",
+    "| `Optimizer(...)` | `_make_optimizer()` |\n",
+    "| `optimizer.solve()` | same |\n",
+    "| `reconstruct_result()` | same |\n",
+    "\n",
+    "The planner also caches `last_program`, `last_optimizer`, and `last_optimization_result` for inspection."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "planner = TrajectoryOptimizationPlanner(\n",
+    "    problem,\n",
+    "    transcription=transcription,\n",
+    "    options=trajopt_options,\n",
+    ")\n",
+    "planner_traj = planner.compute_solution(initial_guess=guess)\n",
+    "wrapper_result = planner.last_optimization_result\n",
+    "\n",
+    "print(\"Planner wrapper vs manual pipeline:\")\n",
+    "print(f\"  n_z match: {planner.last_program.n_z == program.n_z}\")\n",
+    "print(f\"  J* manual  = {manual_result.cost:.6f}\")\n",
+    "print(f\"  J* planner = {wrapper_result.cost:.6f}\")\n",
+    "print(f\"  xy close: {np.allclose(planner_traj.x[0:2], manual_traj.x[0:2], atol=1e-3)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 11 — Workspace cost heatmaps\n",
     "\n",
     "`sample_field_costs` evaluates each grid cell as a **workspace point** with `point_probe` costs (heading-independent tuning view)."
    ]
@@ -459,7 +650,7 @@
     "\n",
     "## MPC closed loop\n",
     "\n",
-    "Now run receding-horizon MPC: re-solve at `MPC_HZ`, hold the first planned input, integrate the (slightly mismatched) plant at `SIM_HZ`."
+    "Each tick: rebuild `PlanningProblem` with measured `x`, call `planner.compute_solution()` (the wrapper above), hold the first planned input, integrate the plant."
    ]
   },
   {
@@ -517,7 +708,7 @@
     "while t < TF_SIM - 1e-12:\n",
     "    if t >= next_mpc_t - 1e-12:\n",
     "        tick_problem = PlanningProblem(sys=sys_mpc, x_start=x, X=X, cost=cost)\n",
-    "        planner = TrajectoryOptimizationPlanner(\n",
+    "        tick_planner = TrajectoryOptimizationPlanner(\n",
     "            tick_problem,\n",
     "            transcription=transcription,\n",
     "            options=trajopt_options,\n",
@@ -539,8 +730,8 @@
     "                tick_problem,\n",
     "                transcription.initial_guess_time_grid(tick_problem),\n",
     "            )\n",
-    "        plan = planner.compute_solution(initial_guess=guess)\n",
-    "        res = planner.last_optimization_result\n",
+    "        plan = tick_planner.compute_solution(initial_guess=guess)\n",
+    "        res = tick_planner.last_optimization_result\n",
     "        print(\n",
     "            f\"MPC @ t={t:.2f}s  success={res.success}  solve={res.solve_time_s:.3f}s\"\n",
     "        )\n",

--- a/examples/notebooks/demo_mpc_spatial_scene_guide.ipynb
+++ b/examples/notebooks/demo_mpc_spatial_scene_guide.ipynb
@@ -1,0 +1,627 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# MPC spatial scene guide (waypoints → problem → solve)\n",
+    "\n",
+    "Pedagogical walkthrough of the `planning/spatial` pipeline for a rate-input dynamic bicycle:\n",
+    "\n",
+    "1. **Workspace** — waypoints, `ReferenceTrack`, sphere obstacles, `Scene` (+ optional terrain).\n",
+    "2. **Body** — `bind(sys, geometry)` turns state `x` into workspace probes.\n",
+    "3. **State fields** — `clearance_field`, `distance_field`, `corridor_field`, `cost_field` expose `value(x)`.\n",
+    "4. **Exports** — `as_constraint()` for hard tubes / free space; `as_cost(shaping=...)` for soft penalties.\n",
+    "5. **Assembly** — compose `X` and `cost`, build `PlanningProblem`, wire direct collocation.\n",
+    "6. **MPC** — closed-loop receding horizon (last section).\n",
+    "\n",
+    "Companion script (no solve): `examples/scripts/mpc/demo_mpc_spatial_scene_guide.py`\n",
+    "\n",
+    "Run from repo root with `pip install -e \".[jax]\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %matplotlib inline\n",
+    "\n",
+    "# Colab setup (uncomment):\n",
+    "# !git clone https://github.com/alx87grd/minilink.git\n",
+    "# %cd minilink\n",
+    "# !pip install -q -e \".[jax]\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "from minilink.core.backends import configure_jax\n",
+    "from minilink.core.costs import QuadraticCost\n",
+    "from minilink.core.geometry import Sphere\n",
+    "from minilink.core.sets import BoxSet\n",
+    "from minilink.core.trajectory import Trajectory\n",
+    "from minilink.dynamics.catalog.vehicles.dynamic_bicycle import JaxDynamicBicycleRateInputs\n",
+    "from minilink.graphical.animation.primitives import HorizonPolyline, TrajectoryPolyline\n",
+    "from minilink.graphical.catalog import SceneHistory\n",
+    "from minilink.planning.initial_guess import default_initial_trajectory\n",
+    "from minilink.planning.problems import PlanningProblem\n",
+    "from minilink.planning.spatial.collision import bind, car_outline, point_probe\n",
+    "from minilink.planning.spatial.grid import pad_bounds, sample_field_costs\n",
+    "from minilink.planning.spatial.paths import from_waypoints\n",
+    "from minilink.planning.spatial.plotting import plot_cost_field_exports\n",
+    "from minilink.planning.spatial.scene import Scene\n",
+    "from minilink.planning.spatial.shaping import (\n",
+    "    inverse_barrier,\n",
+    "    occupancy,\n",
+    "    quadratic_excess,\n",
+    "    quadratic_hinge,\n",
+    ")\n",
+    "from minilink.planning.spatial.track import ReferenceTrack\n",
+    "from minilink.planning.spatial.workspace_fields import GaussianField\n",
+    "from minilink.planning.trajectory_optimization.direct_collocation import (\n",
+    "    DirectCollocationOptions,\n",
+    "    DirectCollocationTranscription,\n",
+    ")\n",
+    "from minilink.planning.trajectory_optimization.planner import (\n",
+    "    TrajectoryOptimizationOptions,\n",
+    "    TrajectoryOptimizationPlanner,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Scenario parameters\n",
+    "\n",
+    "A compact CCW loop, three keepout spheres, and a soft Gaussian terrain patch."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "WAYPOINTS = np.array(\n",
+    "    [\n",
+    "        [-8.0, -5.0],\n",
+    "        [8.0, -5.0],\n",
+    "        [12.0, 0.0],\n",
+    "        [8.0, 5.0],\n",
+    "        [-8.0, 5.0],\n",
+    "        [-12.0, 0.0],\n",
+    "        [-8.0, -5.0],\n",
+    "    ]\n",
+    ")\n",
+    "CORRIDOR_HALF_WIDTH = 2.0\n",
+    "OBSTACLE_RADIUS = 0.35\n",
+    "OBSTACLE_MARGIN = 0.15\n",
+    "OBSTACLE_CENTERS = ((-4.0, -4.0), (4.0, 0.0), (0.0, 4.0))\n",
+    "TERRAIN_CENTER = (2.0, 2.0)\n",
+    "\n",
+    "PATH_COST_WEIGHT = 30.0\n",
+    "CORRIDOR_COST_WEIGHT = 20.0\n",
+    "OBSTACLE_REPULSION_WEIGHT = 25.0\n",
+    "TERRAIN_COST_WEIGHT = 5.0\n",
+    "U_TARGET = 12.0\n",
+    "\n",
+    "PLOT_MARGIN = 2.0\n",
+    "COST_FIELD_MARGIN = 4.0\n",
+    "PLOT_BOUNDS = (\n",
+    "    (WAYPOINTS[:, 0].min() - PLOT_MARGIN, WAYPOINTS[:, 0].max() + PLOT_MARGIN),\n",
+    "    (WAYPOINTS[:, 1].min() - PLOT_MARGIN, WAYPOINTS[:, 1].max() + PLOT_MARGIN),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1 — Planner plant\n",
+    "\n",
+    "`JaxDynamicBicycleRateInputs`: wheel speed and steer angle are **states**; their rates are **inputs**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "configure_jax(enable_x64=True)\n",
+    "\n",
+    "W_REAR_MAX = 90.0\n",
+    "DELTA_MAX = 0.55\n",
+    "W_REAR_DOT_MAX = 80.0\n",
+    "DELTA_DOT_MAX = 2.0\n",
+    "\n",
+    "sys_mpc = JaxDynamicBicycleRateInputs()\n",
+    "sys_mpc.state.lower_bound[6] = 0.0\n",
+    "sys_mpc.state.upper_bound[6] = W_REAR_MAX\n",
+    "sys_mpc.state.lower_bound[7] = -DELTA_MAX\n",
+    "sys_mpc.state.upper_bound[7] = DELTA_MAX\n",
+    "sys_mpc.inputs[\"w_rear_dot\"].lower_bound[0] = -W_REAR_DOT_MAX\n",
+    "sys_mpc.inputs[\"w_rear_dot\"].upper_bound[0] = W_REAR_DOT_MAX\n",
+    "sys_mpc.inputs[\"delta_dot\"].lower_bound[0] = -DELTA_DOT_MAX\n",
+    "sys_mpc.inputs[\"delta_dot\"].upper_bound[0] = DELTA_DOT_MAX\n",
+    "print(f\"n={sys_mpc.n}, m={sys_mpc.m}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2 — Waypoints → `ReferenceTrack`\n",
+    "\n",
+    "`from_waypoints` builds a workspace polyline. `ReferenceTrack` adds a constant half-width corridor.\n",
+    "\n",
+    "Workspace queries (no robot yet):\n",
+    "- `track.distance(p)` — meters to centerline\n",
+    "- `track.corridor_margin(p)` — `half_width - distance` (positive inside the tube)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "track = ReferenceTrack(from_waypoints(WAYPOINTS), half_width=CORRIDOR_HALF_WIDTH)\n",
+    "sample_p = np.array([0.0, -4.0])\n",
+    "print(f\"path length = {track.path.total_length:.2f} m\")\n",
+    "print(f\"distance({sample_p}) = {track.distance(sample_p):.3f}\")\n",
+    "print(f\"corridor_margin({sample_p}) = {track.corridor_margin(sample_p):.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3 — `Scene`: obstacles and terrain\n",
+    "\n",
+    "Hard shapes live in `scene.obstacles`. Soft penalties live in `scene.workspace_fields`.\n",
+    "\n",
+    "Workspace queries:\n",
+    "- `scene.clearance(p)` — signed distance to nearest obstacle (positive in free space)\n",
+    "- `scene.cost_density(p)` — sum of terrain penalty densities\n",
+    "\n",
+    "Factories (need a collision **body** next):\n",
+    "- `scene.clearance_field(body)` → `ClearanceField`\n",
+    "- `scene.cost_field(body)` → `CostDensityField`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "keepout_radius = OBSTACLE_RADIUS + OBSTACLE_MARGIN\n",
+    "scene = Scene(\n",
+    "    obstacles=tuple(Sphere(c, keepout_radius) for c in OBSTACLE_CENTERS),\n",
+    "    workspace_fields=(GaussianField(TERRAIN_CENTER, amplitude=1.0, sigma=2.5),),\n",
+    ")\n",
+    "print(f\"clearance({sample_p}) = {scene.clearance(sample_p):.3f}\")\n",
+    "print(f\"cost_density({sample_p}) = {scene.cost_density(sample_p):.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 4 — Collision body: `bind(sys, geometry)`\n",
+    "\n",
+    "Geometry is **frameless** (`point_probe`, `disc`, `car_outline`). `bind` attaches it to the planner plant so forward kinematics place probes in the workspace — the same transform used for rendering.\n",
+    "\n",
+    "- **MPC planner** — `car_outline` (oriented footprint)\n",
+    "- **Heatmaps** — `point_probe` (workspace position only, heading-independent)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "body = bind(sys_mpc, car_outline(length=2.2, width=0.2, margin=0.05))\n",
+    "probe = bind(sys_mpc, point_probe())\n",
+    "\n",
+    "r_r = sys_mpc.params[\"r_r\"]\n",
+    "w_rear_ref = U_TARGET / r_r\n",
+    "x_cruise = np.array([0.0, -4.0, 0.0, U_TARGET, 0.0, 0.0, w_rear_ref, 0.0])\n",
+    "ubar = np.zeros(sys_mpc.m)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 5 — State fields: `value(x)`\n",
+    "\n",
+    "Each field fuses workspace queries over all body probes (min clearance / distance, max terrain density).\n",
+    "\n",
+    "Track factories mirror the scene pattern:\n",
+    "- `track.distance_field(body)` → `PathDistanceField`\n",
+    "- `track.corridor_field(body)` → `CorridorMarginField`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clearance_field = scene.clearance_field(body)\n",
+    "corridor_field = track.corridor_field(body)\n",
+    "distance_field = track.distance_field(body)\n",
+    "terrain_field = scene.cost_field(body)\n",
+    "\n",
+    "for name, field in [\n",
+    "    (\"clearance\", clearance_field),\n",
+    "    (\"corridor\", corridor_field),\n",
+    "    (\"path distance\", distance_field),\n",
+    "    (\"terrain\", terrain_field),\n",
+    "]:\n",
+    "    print(f\"{name:14s} value(x_cruise) = {float(field.value(x_cruise)):.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 6 — Hard set: `field.as_constraint()`\n",
+    "\n",
+    "`FieldSet` is feasible where `lower <= value(x) <= upper`. Compose with `&`:\n",
+    "\n",
+    "```\n",
+    "X = state_bounds & obstacle_free & corridor_tube\n",
+    "```\n",
+    "\n",
+    "Direct collocation enforces `X.contains(x_k)` at each node. MPC demos often skip hard `X` and rely on soft costs only; both patterns are shown here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X = (\n",
+    "    BoxSet.from_system_state(sys_mpc)\n",
+    "    & clearance_field.as_constraint(lower=0.0)\n",
+    "    & corridor_field.as_constraint(lower=0.0)\n",
+    ")\n",
+    "print(\"X assembled: bounds ∩ obstacle clearance ≥ 0 ∩ corridor margin ≥ 0\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 7 — Soft cost: `field.as_cost(shaping=...)`\n",
+    "\n",
+    "Shaping maps the raw field value to a penalty **before** weighting:\n",
+    "\n",
+    "| Shaping | Use with | Effect |\n",
+    "| --- | --- | --- |\n",
+    "| `quadratic_excess` | path distance | quadratic once farther than threshold from centerline |\n",
+    "| `quadratic_hinge` | corridor margin | quadratic once outside the tube |\n",
+    "| `inverse_barrier` | clearance | blows up as clearance → 0 |\n",
+    "| `occupancy` | terrain density | bounded sigmoid in [0, 1] |\n",
+    "\n",
+    "Compose with `+` on `CostFunction` terms."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stability_cost = QuadraticCost.from_system(\n",
+    "    sys_mpc,\n",
+    "    Q=np.diag([0.0, 0.0, 0.0, 0.15, 4.0, 6.0, 0.1, 80.0]),\n",
+    "    R=np.diag([1.0, 22.0]),\n",
+    "    S=np.diag([0.0, 0.0, 0.0, 0.15, 4.0, 6.0, 0.1, 80.0]),\n",
+    "    xbar=x_cruise,\n",
+    "    ubar=ubar,\n",
+    ")\n",
+    "path_cost = distance_field.as_cost(\n",
+    "    weight=PATH_COST_WEIGHT, shaping=quadratic_excess(threshold=0.1)\n",
+    ")\n",
+    "corridor_cost = corridor_field.as_cost(\n",
+    "    weight=CORRIDOR_COST_WEIGHT, shaping=quadratic_hinge(threshold=0.0)\n",
+    ")\n",
+    "obstacle_cost = clearance_field.as_cost(\n",
+    "    weight=OBSTACLE_REPULSION_WEIGHT, shaping=inverse_barrier(epsilon=0.08)\n",
+    ")\n",
+    "terrain_cost = terrain_field.as_cost(\n",
+    "    weight=TERRAIN_COST_WEIGHT, shaping=occupancy(scale=1.0)\n",
+    ")\n",
+    "cost = stability_cost + path_cost + corridor_cost + obstacle_cost + terrain_cost"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 8 — `PlanningProblem`\n",
+    "\n",
+    "Receding-horizon MPC rebuilds `PlanningProblem(sys, x_start=x, cost=cost)` each tick with the measured state."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "problem = PlanningProblem(sys=sys_mpc, x_start=x_cruise, X=X, cost=cost)\n",
+    "print(problem)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 9 — Direct collocation planner (preview)\n",
+    "\n",
+    "Transcription discretizes the horizon; `TrajectoryOptimizationPlanner` compiles and solves the NLP. The MPC section below calls `compute_solution` in a loop."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MPC_HORIZON = 2.0\n",
+    "MPC_STEPS = 20\n",
+    "MPC_MAXITER = 120\n",
+    "MPC_FTOL = 1e-1\n",
+    "\n",
+    "transcription = DirectCollocationTranscription(\n",
+    "    DirectCollocationOptions(tf=MPC_HORIZON, n_steps=MPC_STEPS)\n",
+    ")\n",
+    "trajopt_options = TrajectoryOptimizationOptions(\n",
+    "    compile_backend=\"jax\",\n",
+    "    optimizer_method=\"scipy_slsqp\",\n",
+    "    solve_disp=False,\n",
+    "    record_solve_time=True,\n",
+    "    optimizer_options={\"maxiter\": MPC_MAXITER, \"ftol\": MPC_FTOL},\n",
+    ")\n",
+    "print(f\"horizon {MPC_HORIZON}s, {MPC_STEPS} collocation nodes\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 10 — Workspace cost heatmaps\n",
+    "\n",
+    "`sample_field_costs` evaluates each grid cell as a **workspace point** with `point_probe` costs (heading-independent tuning view)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "path_cost_viz = track.distance_field(probe).as_cost(\n",
+    "    weight=PATH_COST_WEIGHT, shaping=quadratic_excess(threshold=0.1)\n",
+    ")\n",
+    "corridor_cost_viz = track.corridor_field(probe).as_cost(\n",
+    "    weight=CORRIDOR_COST_WEIGHT, shaping=quadratic_hinge(threshold=0.0)\n",
+    ")\n",
+    "obstacle_cost_viz = scene.clearance_field(probe).as_cost(\n",
+    "    weight=OBSTACLE_REPULSION_WEIGHT, shaping=inverse_barrier(epsilon=0.08)\n",
+    ")\n",
+    "cost_bounds = pad_bounds(PLOT_BOUNDS, COST_FIELD_MARGIN - PLOT_MARGIN)\n",
+    "_cost_kw = dict(bounds=cost_bounds, state_dim=sys_mpc.n, grid=(100, 100))\n",
+    "layers = {\n",
+    "    \"path\": sample_field_costs([path_cost_viz], **_cost_kw),\n",
+    "    \"corridor\": sample_field_costs([corridor_cost_viz], **_cost_kw),\n",
+    "    \"obstacle\": sample_field_costs([obstacle_cost_viz], **_cost_kw),\n",
+    "    \"combined\": sample_field_costs(\n",
+    "        [path_cost_viz, corridor_cost_viz, obstacle_cost_viz], **_cost_kw\n",
+    "    ),\n",
+    "}\n",
+    "\n",
+    "_, ax = scene.plot(show=False, bounds=PLOT_BOUNDS, show_density=True, title=\"\")\n",
+    "track.plot(show=False, ax=ax, bounds=PLOT_BOUNDS, title=\"\")\n",
+    "ax.set_title(\"Scene + reference track\")\n",
+    "plt.show()\n",
+    "\n",
+    "plot_cost_field_exports(\n",
+    "    layers,\n",
+    "    track=track,\n",
+    "    scene=scene,\n",
+    "    overlay_bounds=PLOT_BOUNDS,\n",
+    "    log_scale=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## MPC closed loop\n",
+    "\n",
+    "Now run receding-horizon MPC: re-solve at `MPC_HZ`, hold the first planned input, integrate the (slightly mismatched) plant at `SIM_HZ`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TF_SIM = 8.0\n",
+    "VX0 = 8.0\n",
+    "MPC_HZ = 5.0\n",
+    "SIM_HZ = 200.0\n",
+    "MPC_DT = 1.0 / MPC_HZ\n",
+    "SIM_DT = 1.0 / SIM_HZ\n",
+    "SUBSTEPS = max(1, int(round(MPC_DT / SIM_DT)))\n",
+    "\n",
+    "sys_sim = JaxDynamicBicycleRateInputs()\n",
+    "sys_sim.params[\"mass\"] = 1.03 * sys_mpc.params[\"mass\"]\n",
+    "sys_sim.params[\"inertia\"] = 1.02 * sys_mpc.params[\"inertia\"]\n",
+    "for sys in (sys_mpc, sys_sim):\n",
+    "    sys.state.lower_bound[6] = 0.0\n",
+    "    sys.state.upper_bound[6] = W_REAR_MAX\n",
+    "    sys.state.lower_bound[7] = -DELTA_MAX\n",
+    "    sys.state.upper_bound[7] = DELTA_MAX\n",
+    "    sys.inputs[\"w_rear_dot\"].lower_bound[0] = -W_REAR_DOT_MAX\n",
+    "    sys.inputs[\"w_rear_dot\"].upper_bound[0] = W_REAR_DOT_MAX\n",
+    "    sys.inputs[\"delta_dot\"].lower_bound[0] = -DELTA_DOT_MAX\n",
+    "    sys.inputs[\"delta_dot\"].upper_bound[0] = DELTA_DOT_MAX\n",
+    "\n",
+    "s_start, _ = track.path.project(WAYPOINTS[0])\n",
+    "tangent = track.path.tangent(s_start)\n",
+    "theta0 = float(np.arctan2(tangent[1], tangent[0]))\n",
+    "x0 = np.array(\n",
+    "    [WAYPOINTS[0, 0], WAYPOINTS[0, 1], theta0, VX0, 0.0, 0.0, VX0 / r_r, 0.0]\n",
+    ")\n",
+    "sim_evaluator = sys_sim.compile(backend=\"jax\", verbose=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "t_hist = [0.0]\n",
+    "x_hist = [x0.copy()]\n",
+    "u_hist = [np.zeros(sys_sim.m)]\n",
+    "mpc_plans = []\n",
+    "x = x0.copy()\n",
+    "t = 0.0\n",
+    "u_hold = np.zeros(sys_sim.m)\n",
+    "prev_plan = None\n",
+    "next_mpc_t = 0.0\n",
+    "\n",
+    "while t < TF_SIM - 1e-12:\n",
+    "    if t >= next_mpc_t - 1e-12:\n",
+    "        tick_problem = PlanningProblem(sys=sys_mpc, x_start=x, X=X, cost=cost)\n",
+    "        planner = TrajectoryOptimizationPlanner(\n",
+    "            tick_problem,\n",
+    "            transcription=transcription,\n",
+    "            options=trajopt_options,\n",
+    "        )\n",
+    "        guess = None\n",
+    "        if prev_plan is not None and prev_plan.n_samples >= 3:\n",
+    "            t_shift = prev_plan.t + MPC_DT\n",
+    "            mask = t_shift <= t + MPC_HORIZON + 1e-9\n",
+    "            if np.count_nonzero(mask) >= 3:\n",
+    "                x_guess = prev_plan.x[:, mask].copy()\n",
+    "                x_guess[:, 0] = x\n",
+    "                guess = Trajectory(\n",
+    "                    t=t_shift[mask] - t,\n",
+    "                    x=x_guess,\n",
+    "                    u=prev_plan.u[:, mask],\n",
+    "                )\n",
+    "        else:\n",
+    "            guess = default_initial_trajectory(\n",
+    "                tick_problem,\n",
+    "                transcription.initial_guess_time_grid(tick_problem),\n",
+    "            )\n",
+    "        plan = planner.compute_solution(initial_guess=guess)\n",
+    "        res = planner.last_optimization_result\n",
+    "        print(\n",
+    "            f\"MPC @ t={t:.2f}s  success={res.success}  solve={res.solve_time_s:.3f}s\"\n",
+    "        )\n",
+    "        prev_plan = plan\n",
+    "        u_hold = plan.u[:, 0].copy()\n",
+    "        mpc_plans.append(\n",
+    "            (t, Trajectory(t=plan.t + t, x=plan.x.copy(), u=plan.u.copy()))\n",
+    "        )\n",
+    "        next_mpc_t += MPC_DT\n",
+    "\n",
+    "    for _ in range(SUBSTEPS):\n",
+    "        if t >= TF_SIM:\n",
+    "            break\n",
+    "        x = sim_evaluator.rk4_step(x, u_hold, t, SIM_DT)\n",
+    "        t += SIM_DT\n",
+    "        t_hist.append(t)\n",
+    "        x_hist.append(x.copy())\n",
+    "        u_hist.append(u_hold.copy())\n",
+    "\n",
+    "traj = Trajectory(\n",
+    "    t=np.asarray(t_hist), x=np.asarray(x_hist).T, u=np.asarray(u_hist).T\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Results\n",
+    "\n",
+    "Executed path on the scene, then state/input histories."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_, ax = scene.plot(\n",
+    "    show=False,\n",
+    "    bounds=PLOT_BOUNDS,\n",
+    "    title=\"MPC on spatial scene\",\n",
+    "    show_density=False,\n",
+    ")\n",
+    "track.plot(show=False, ax=ax, bounds=PLOT_BOUNDS, title=\"\")\n",
+    "ax.plot(traj.x[0, :], traj.x[1, :], color=\"tab:blue\", linewidth=1.5, label=\"executed\")\n",
+    "ax.legend(loc=\"upper left\")\n",
+    "plt.show()\n",
+    "\n",
+    "sys_sim.params = dict(sys_sim.params)\n",
+    "sys_sim.camera_scale = 14.0\n",
+    "sys_sim.traj = traj\n",
+    "sys_sim.plot_trajectory(signals=(\"x\", \"u\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "history = SceneHistory(\n",
+    "    trail=TrajectoryPolyline(traj, window=\"prefix\", color=\"b\", style=\"--\", linewidth=1.0),\n",
+    "    horizon=HorizonPolyline(mpc_plans, color=\"tab:orange\", linewidth=2.0, style=\"--\"),\n",
+    ")\n",
+    "sys_sim.animate(traj, overlays=[scene.as_visualizer(color=\"tab:red\", opacity=0.45), history])"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/scripts/mpc/demo_dynamic_bicycle_rate_mpc_wide_circuit_lap.py
+++ b/examples/scripts/mpc/demo_dynamic_bicycle_rate_mpc_wide_circuit_lap.py
@@ -27,9 +27,11 @@ from minilink.planning.mpc import (
     MPCPlanner,
 )
 from minilink.planning.problems import PlanningProblem
-from minilink.planning.spatial.collision import bind, car_outline
+from minilink.planning.spatial.collision import bind, car_outline, point_probe
+from minilink.planning.spatial.grid import pad_bounds, sample_field_costs
 from minilink.planning.spatial.overlays import TrackCorridorOverlay
 from minilink.planning.spatial.paths import from_waypoints
+from minilink.planning.spatial.plotting import plot_cost_field_exports
 from minilink.planning.spatial.scene import Scene
 from minilink.planning.spatial.shaping import (
     inverse_barrier,
@@ -98,6 +100,7 @@ W_REAR_DOT_MAX = 80.0
 DELTA_DOT_MAX = 2.0
 CAMERA_SCALE = 18.0
 PLOT_MARGIN = 3.0
+COST_FIELD_MARGIN = 6.0
 
 
 def _quarter_arc_waypoints(cx, cy, radius, angle_start, n=10):
@@ -221,6 +224,7 @@ track = ReferenceTrack(
     from_waypoints(REFERENCE_WAYPOINTS), half_width=CORRIDOR_HALF_WIDTH
 )
 body = bind(sys_mpc, car_outline(length=2.4, width=0.2, margin=0.05))
+probe = bind(sys_mpc, point_probe())
 scene = Scene(
     obstacles=tuple(Sphere(center, keepout_radius) for center in OBSTACLE_CENTERS)
 )
@@ -245,7 +249,20 @@ obstacle_cost = scene.clearance_field(body).as_cost(
     weight=OBSTACLE_REPULSION_WEIGHT,
     shaping=inverse_barrier(epsilon=OBSTACLE_REPULSION_EPS),
 )
-
+# Workspace heatmaps: point probe at each (x, y) — heading-independent tuning view.
+# MPC costs above still use car_outline for the planner body.
+path_cost_viz = track.distance_field(probe).as_cost(
+    weight=PATH_COST_WEIGHT,
+    shaping=quadratic_excess(threshold=0.1),
+)
+corridor_cost_viz = track.corridor_field(probe).as_cost(
+    weight=CORRIDOR_COST_WEIGHT,
+    shaping=quadratic_hinge(threshold=0.0),
+)
+obstacle_cost_viz = scene.clearance_field(probe).as_cost(
+    weight=OBSTACLE_REPULSION_WEIGHT,
+    shaping=inverse_barrier(epsilon=OBSTACLE_REPULSION_EPS),
+)
 cost = stability_cost + path_cost + corridor_cost + obstacle_cost
 
 s_start, _ = loop_track.path.project(START_XY)
@@ -401,6 +418,25 @@ ax.scatter(
 ax.legend(loc="upper left", fontsize=8)
 fig.tight_layout()
 plt.show()
+
+COST_FIELD_BOUNDS = pad_bounds(PLOT_BOUNDS, COST_FIELD_MARGIN - PLOT_MARGIN)
+_cost_kw = dict(bounds=COST_FIELD_BOUNDS, state_dim=sys_mpc.n)
+
+plot_cost_field_exports(
+    {
+        "path": sample_field_costs([path_cost_viz], **_cost_kw),
+        "corridor": sample_field_costs([corridor_cost_viz], **_cost_kw),
+        "obstacle": sample_field_costs([obstacle_cost_viz], **_cost_kw),
+        "combined": sample_field_costs(
+            [path_cost_viz, corridor_cost_viz, obstacle_cost_viz], **_cost_kw
+        ),
+    },
+    track=loop_track,
+    scene=scene,
+    overlay_bounds=PLOT_BOUNDS,
+    traj=traj.x[0:2, :],
+    log_scale=True,
+)
 
 
 # --- Animation ---

--- a/examples/scripts/mpc/demo_mpc_spatial_scene_guide.py
+++ b/examples/scripts/mpc/demo_mpc_spatial_scene_guide.py
@@ -1,0 +1,310 @@
+"""Pedagogical guide: waypoints and obstacles → MPC problem (no solve).
+
+Walks through the ``planning/spatial`` pipeline for a rate-input dynamic bicycle:
+
+1. **Workspace geometry** — waypoint polyline, :class:`ReferenceTrack`, sphere obstacles,
+   :class:`Scene`.
+2. **Collision body** — ``bind(sys, geometry)`` maps state ``x`` to workspace probes
+   (``point_probe``, ``disc``, ``car_outline``).
+3. **State fields** — scalar ``value(x)`` from scene/track queries fused over the body.
+4. **Exports** — ``as_constraint()`` for hard feasible sets, ``as_cost(shaping=...)``
+   for soft penalties (:func:`~minilink.planning.spatial.shaping.quadratic_excess`,
+   :func:`~minilink.planning.spatial.shaping.quadratic_hinge`,
+   :func:`~minilink.planning.spatial.shaping.inverse_barrier`,
+   :func:`~minilink.planning.spatial.shaping.occupancy`).
+5. **Assembly** — compose ``X`` and ``cost``, build :class:`PlanningProblem`,
+   wire direct collocation — then stop before the MPC loop.
+
+Set ``SHOW_PLOTS = False`` for a headless walkthrough.
+
+Run from repo root::
+
+    python examples/scripts/mpc/demo_mpc_spatial_scene_guide.py
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from minilink.core.backends import configure_jax
+from minilink.core.costs import QuadraticCost
+from minilink.core.geometry import Sphere
+from minilink.core.sets import BoxSet
+from minilink.dynamics.catalog.vehicles.dynamic_bicycle import (
+    JaxDynamicBicycleRateInputs,
+)
+from minilink.planning.problems import PlanningProblem
+from minilink.planning.spatial.collision import bind, car_outline, point_probe
+from minilink.planning.spatial.grid import pad_bounds, sample_field_costs
+from minilink.planning.spatial.paths import from_waypoints
+from minilink.planning.spatial.plotting import plot_cost_field_exports
+from minilink.planning.spatial.scene import Scene
+from minilink.planning.spatial.shaping import (
+    inverse_barrier,
+    occupancy,
+    quadratic_excess,
+    quadratic_hinge,
+)
+from minilink.planning.spatial.track import ReferenceTrack
+from minilink.planning.spatial.workspace_fields import GaussianField
+from minilink.planning.trajectory_optimization.direct_collocation import (
+    DirectCollocationOptions,
+    DirectCollocationTranscription,
+)
+from minilink.planning.trajectory_optimization.planner import (
+    TrajectoryOptimizationOptions,
+    TrajectoryOptimizationPlanner,
+)
+
+# --- Teaching scenario (compact loop + a few obstacles) ---
+WAYPOINTS = np.array(
+    [
+        [-8.0, -5.0],
+        [8.0, -5.0],
+        [12.0, 0.0],
+        [8.0, 5.0],
+        [-8.0, 5.0],
+        [-12.0, 0.0],
+        [-8.0, -5.0],
+    ]
+)
+CORRIDOR_HALF_WIDTH = 2.0
+OBSTACLE_RADIUS = 0.35
+OBSTACLE_MARGIN = 0.15
+OBSTACLE_CENTERS = ((-4.0, -4.0), (4.0, 0.0), (0.0, 4.0))
+TERRAIN_CENTER = (2.0, 2.0)
+
+PATH_COST_WEIGHT = 30.0
+CORRIDOR_COST_WEIGHT = 20.0
+OBSTACLE_REPULSION_WEIGHT = 25.0
+TERRAIN_COST_WEIGHT = 5.0
+U_TARGET = 12.0
+
+MPC_HORIZON = 2.0
+MPC_STEPS = 20
+MPC_MAXITER = 120
+MPC_FTOL = 1e-1
+
+W_REAR_MAX = 90.0
+DELTA_MAX = 0.55
+W_REAR_DOT_MAX = 80.0
+DELTA_DOT_MAX = 2.0
+
+PLOT_MARGIN = 2.0
+COST_FIELD_MARGIN = 4.0
+SHOW_PLOTS = True
+
+
+def _section(title: str) -> None:
+    print(f"\n=== {title} ===")
+
+
+def _print_field(name: str, value: float) -> None:
+    print(f"  {name} = {value:.4f}")
+
+
+# ---------------------------------------------------------------------------
+# Step 1 — Planner plant (rate-input bicycle used inside MPC transcription)
+# ---------------------------------------------------------------------------
+_section("Step 1: planner plant")
+configure_jax(enable_x64=True)
+
+sys_mpc = JaxDynamicBicycleRateInputs()
+sys_mpc.state.lower_bound[6] = 0.0
+sys_mpc.state.upper_bound[6] = W_REAR_MAX
+sys_mpc.state.lower_bound[7] = -DELTA_MAX
+sys_mpc.state.upper_bound[7] = DELTA_MAX
+sys_mpc.inputs["w_rear_dot"].lower_bound[0] = -W_REAR_DOT_MAX
+sys_mpc.inputs["w_rear_dot"].upper_bound[0] = W_REAR_DOT_MAX
+sys_mpc.inputs["delta_dot"].lower_bound[0] = -DELTA_DOT_MAX
+sys_mpc.inputs["delta_dot"].upper_bound[0] = DELTA_DOT_MAX
+print(f"  state dim n={sys_mpc.n}, input dim m={sys_mpc.m}")
+
+# ---------------------------------------------------------------------------
+# Step 2 — Waypoints → ReferencePath → ReferenceTrack
+# ---------------------------------------------------------------------------
+_section("Step 2: reference track from waypoints")
+path = from_waypoints(WAYPOINTS)
+track = ReferenceTrack(path, half_width=CORRIDOR_HALF_WIDTH)
+print(f"  centerline length = {path.total_length:.2f} m")
+print(f"  corridor half-width = {track.half_width:.2f} m")
+
+sample_p = np.array([0.0, -4.0])
+_print_field("track.distance(sample)", float(track.distance(sample_p)))
+_print_field(
+    "track.corridor_margin(sample)",
+    float(track.corridor_margin(sample_p)),
+)
+
+# ---------------------------------------------------------------------------
+# Step 3 — Obstacles (+ optional soft terrain) → Scene
+# ---------------------------------------------------------------------------
+_section("Step 3: scene — hard obstacles and soft workspace fields")
+keepout_radius = OBSTACLE_RADIUS + OBSTACLE_MARGIN
+scene = Scene(
+    obstacles=tuple(Sphere(center, keepout_radius) for center in OBSTACLE_CENTERS),
+    workspace_fields=(GaussianField(TERRAIN_CENTER, amplitude=1.0, sigma=2.5),),
+)
+_print_field("scene.clearance(sample)", float(scene.clearance(sample_p)))
+_print_field("scene.cost_density(sample)", float(scene.cost_density(sample_p)))
+print("  Scene factories:")
+print("    scene.clearance_field(body)  → min body clearance to obstacles")
+print("    scene.cost_field(body)       → max body exposure to terrain density")
+
+# ---------------------------------------------------------------------------
+# Step 4 — Collision body: state x → workspace probes
+# ---------------------------------------------------------------------------
+_section("Step 4: collision body via bind(sys, geometry)")
+body = bind(sys_mpc, car_outline(length=2.2, width=0.2, margin=0.05))
+probe = bind(sys_mpc, point_probe())
+print("  car_outline — MPC planner body (oriented footprint)")
+print("  point_probe — workspace heatmaps (position only, no heading)")
+
+r_r = sys_mpc.params["r_r"]
+w_rear_ref = U_TARGET / r_r
+x_cruise = np.array([0.0, -4.0, 0.0, U_TARGET, 0.0, 0.0, w_rear_ref, 0.0])
+ubar = np.zeros(sys_mpc.m)
+
+# ---------------------------------------------------------------------------
+# Step 5 — State fields: scalar value(x) over the body
+# ---------------------------------------------------------------------------
+_section("Step 5: state fields — value(x) at cruise pose")
+clearance_field = scene.clearance_field(body)
+corridor_field = track.corridor_field(body)
+distance_field = track.distance_field(body)
+terrain_field = scene.cost_field(body)
+_print_field("clearance_field.value(x)", float(clearance_field.value(x_cruise)))
+_print_field("corridor_field.value(x)", float(corridor_field.value(x_cruise)))
+_print_field("distance_field.value(x)", float(distance_field.value(x_cruise)))
+_print_field("terrain_field.value(x)", float(terrain_field.value(x_cruise)))
+
+# ---------------------------------------------------------------------------
+# Step 6 — Hard feasible set: field.as_constraint()
+# ---------------------------------------------------------------------------
+_section("Step 6: hard constraints — field.as_constraint()")
+X = (
+    BoxSet.from_system_state(sys_mpc)
+    & clearance_field.as_constraint(lower=0.0)
+    & corridor_field.as_constraint(lower=0.0)
+)
+print("  X = state_bounds & obstacle_free & corridor_tube")
+print("  margin(z) > 0  ↔  feasible along a trajectory node")
+
+# ---------------------------------------------------------------------------
+# Step 7 — Soft costs: field.as_cost(shaping=...)
+# ---------------------------------------------------------------------------
+_section("Step 7: soft costs — field.as_cost(shaping=...)")
+stability_cost = QuadraticCost.from_system(
+    sys_mpc,
+    Q=np.diag([0.0, 0.0, 0.0, 0.15, 4.0, 6.0, 0.1, 80.0]),
+    R=np.diag([1.0, 22.0]),
+    S=np.diag([0.0, 0.0, 0.0, 0.15, 4.0, 6.0, 0.1, 80.0]),
+    xbar=x_cruise,
+    ubar=ubar,
+)
+path_cost = distance_field.as_cost(
+    weight=PATH_COST_WEIGHT,
+    shaping=quadratic_excess(threshold=0.1),
+)
+corridor_cost = corridor_field.as_cost(
+    weight=CORRIDOR_COST_WEIGHT,
+    shaping=quadratic_hinge(threshold=0.0),
+)
+obstacle_cost = clearance_field.as_cost(
+    weight=OBSTACLE_REPULSION_WEIGHT,
+    shaping=inverse_barrier(epsilon=0.08),
+)
+terrain_cost = terrain_field.as_cost(
+    weight=TERRAIN_COST_WEIGHT,
+    shaping=occupancy(scale=1.0),
+)
+print("  quadratic_excess  — penalize path distance above threshold")
+print("  quadratic_hinge   — penalize leaving the corridor tube")
+print("  inverse_barrier   — blow up as clearance → 0")
+print("  occupancy         — bounded [0,1] terrain score")
+
+cost = stability_cost + path_cost + corridor_cost + obstacle_cost + terrain_cost
+print("  cost = stability + path + corridor + obstacle + terrain  (CostFunction +)")
+
+# Separate viz-only costs (point probe, for workspace heatmaps)
+path_cost_viz = track.distance_field(probe).as_cost(
+    weight=PATH_COST_WEIGHT, shaping=quadratic_excess(threshold=0.1)
+)
+corridor_cost_viz = track.corridor_field(probe).as_cost(
+    weight=CORRIDOR_COST_WEIGHT, shaping=quadratic_hinge(threshold=0.0)
+)
+obstacle_cost_viz = scene.clearance_field(probe).as_cost(
+    weight=OBSTACLE_REPULSION_WEIGHT, shaping=inverse_barrier(epsilon=0.08)
+)
+
+# ---------------------------------------------------------------------------
+# Step 8 — PlanningProblem (MPC passes x_start each tick; no x_goal here)
+# ---------------------------------------------------------------------------
+_section("Step 8: PlanningProblem")
+problem = PlanningProblem(sys=sys_mpc, x_start=x_cruise, X=X, cost=cost)
+print("  Receding-horizon MPC uses: PlanningProblem(sys, x_start=x, cost=cost)")
+print("  Hard X is optional; this guide includes it to show the full export path.")
+
+# ---------------------------------------------------------------------------
+# Step 9 — Transcription + planner (assembled, not solved)
+# ---------------------------------------------------------------------------
+_section("Step 9: direct collocation planner (not solved)")
+transcription = DirectCollocationTranscription(
+    DirectCollocationOptions(tf=MPC_HORIZON, n_steps=MPC_STEPS)
+)
+planner = TrajectoryOptimizationPlanner(
+    problem,
+    transcription=transcription,
+    options=TrajectoryOptimizationOptions(
+        compile_backend="jax",
+        optimizer_method="scipy_slsqp",
+        solve_disp=False,
+        optimizer_options={"maxiter": MPC_MAXITER, "ftol": MPC_FTOL},
+    ),
+)
+print(f"  horizon={MPC_HORIZON}s, n_steps={MPC_STEPS}")
+print("  Next step in a full MPC demo: planner.compute_solution(initial_guess=...)")
+
+# ---------------------------------------------------------------------------
+# Step 10 — Workspace cost heatmaps (point probe, heading-independent)
+# ---------------------------------------------------------------------------
+_section("Step 10: workspace cost raster for tuning")
+PLOT_BOUNDS = (
+    (WAYPOINTS[:, 0].min() - PLOT_MARGIN, WAYPOINTS[:, 0].max() + PLOT_MARGIN),
+    (WAYPOINTS[:, 1].min() - PLOT_MARGIN, WAYPOINTS[:, 1].max() + PLOT_MARGIN),
+)
+cost_bounds = pad_bounds(PLOT_BOUNDS, COST_FIELD_MARGIN - PLOT_MARGIN)
+_cost_kw = dict(bounds=cost_bounds, state_dim=sys_mpc.n, grid=(120, 120))
+layers = {
+    "path": sample_field_costs([path_cost_viz], **_cost_kw),
+    "corridor": sample_field_costs([corridor_cost_viz], **_cost_kw),
+    "obstacle": sample_field_costs([obstacle_cost_viz], **_cost_kw),
+    "combined": sample_field_costs(
+        [path_cost_viz, corridor_cost_viz, obstacle_cost_viz], **_cost_kw
+    ),
+}
+print("  sample_field_costs rasterizes FieldCost terms at workspace (x, y)")
+print("  plot_cost_field_exports → per-layer 2D heatmaps + 3D surfaces")
+
+if SHOW_PLOTS:
+    _, ax_scene = scene.plot(
+        show=False,
+        bounds=PLOT_BOUNDS,
+        title="Scene: obstacles + terrain density",
+        show_density=True,
+    )
+    track.plot(show=False, ax=ax_scene, bounds=PLOT_BOUNDS, title="")
+    ax_scene.set_title("Scene + reference track")
+    plt.tight_layout()
+
+    plot_cost_field_exports(
+        layers,
+        track=track,
+        scene=scene,
+        overlay_bounds=PLOT_BOUNDS,
+        log_scale=True,
+        show=True,
+    )
+
+print(
+    "\nDone — MPC problem assembled. See demo_mpc_spatial_scene_guide.ipynb for MPC solve."
+)

--- a/minilink/planning/spatial/grid.py
+++ b/minilink/planning/spatial/grid.py
@@ -4,11 +4,12 @@ Backend-neutral rasters of a scalar field on a 2-D grid.
 :func:`sample_grid` evaluates a scalar query ``fn(p, t, params)`` over an
 axis-aligned grid and returns a :class:`FieldGrid` of plain NumPy arrays — no
 matplotlib. Scenes and state fields use it to rasterize clearance and
-cost-density queries for heatmaps and grid planners; rendering lives in
+cost-density queries for heatmaps; :func:`sample_field_costs` rasterizes shaped
+``FieldCost`` terms for MPC tuning plots in
 :mod:`minilink.planning.spatial.plotting`.
 """
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
 import numpy as np
@@ -76,3 +77,42 @@ def sample_grid(
         for i, x in enumerate(xs):
             Z[j, i] = float(fn(np.array([x, y]), t, params))
     return FieldGrid(xs, ys, Z)
+
+
+def pad_bounds(bounds, padding: float):
+    """Expand axis-aligned ``((x_lo, x_hi), (y_lo, y_hi))`` bounds by ``padding``."""
+    (x_lo, x_hi), (y_lo, y_hi) = bounds
+    pad = float(padding)
+    return ((x_lo - pad, x_hi + pad), (y_lo - pad, y_hi + pad))
+
+
+def sample_field_costs(
+    costs: Sequence,
+    *,
+    bounds,
+    grid: tuple = (200, 200),
+    state_dim: int = 2,
+    u=None,
+    t: float = 0.0,
+    params=None,
+) -> FieldGrid:
+    """
+    Rasterize shaped ``FieldCost`` terms on a workspace XY grid.
+
+    Each cell is the cost of a **workspace point** ``p = (x, y)`` using a
+    **point probe** — build costs with ``bind(sys, point_probe())`` so the
+    field does not depend on robot heading or body extent. ``state_dim`` must
+    match the planner plant state size (``sys.n``).
+    """
+    if not costs:
+        raise ValueError("sample_field_costs requires at least one cost")
+
+    u_use = np.zeros(1) if u is None else u
+    x = np.zeros(int(state_dim))
+
+    def fn(p, t_query=0.0, params_query=None):
+        x[0] = p[0]
+        x[1] = p[1]
+        return sum(float(c.g(x, u_use, t=t_query, params=params_query)) for c in costs)
+
+    return sample_grid(fn, bounds, grid=grid, t=t, params=params)

--- a/minilink/planning/spatial/plotting.py
+++ b/minilink/planning/spatial/plotting.py
@@ -11,7 +11,7 @@ import numpy as np
 
 from minilink.core.geometry import Box, Inflated, Sphere, Union
 from minilink.planning.spatial.collision import iter_probes
-from minilink.planning.spatial.grid import sample_grid
+from minilink.planning.spatial.grid import FieldGrid, sample_grid
 from minilink.planning.spatial.workspace_fields import GaussianField
 
 # Public API
@@ -136,6 +136,310 @@ def plot_scene(
         plt.show()
 
     return fig, ax
+
+
+def _cost_field_array(
+    grid: FieldGrid,
+    *,
+    log_scale: bool = False,
+    vmax: float | None = None,
+    vmax_percentile: float = 99.0,
+    normalize_range: bool = True,
+) -> tuple[np.ndarray, float, float, str]:
+    """Return display values, vmin, vmax, and colorbar label."""
+    z = np.asarray(grid.Z, dtype=float)
+    label = "log(1 + cost)" if log_scale else "cost"
+    if log_scale:
+        z = np.log1p(np.maximum(z, 0.0))
+    vmin = 0.0
+    if normalize_range:
+        finite = z[np.isfinite(z)]
+        if finite.size:
+            vmin = float(np.min(finite))
+            z = z - vmin
+    if vmax is None:
+        finite = z[np.isfinite(z)]
+        if finite.size:
+            vmax = float(np.percentile(finite, vmax_percentile))
+        else:
+            vmax = 1.0
+    if vmax <= 0.0:
+        vmax = 1.0
+    return z, vmin, vmax, label
+
+
+def cost_field_cmap():
+    """Low cost (blue) to high cost (red) — matplotlib ``turbo``."""
+    import matplotlib.pyplot as plt
+
+    return plt.get_cmap("turbo")
+
+
+def _cost_field_norm(vmax: float, *, gamma: float = 0.55):
+    from matplotlib.colors import PowerNorm
+
+    return PowerNorm(gamma=gamma, vmin=0.0, vmax=vmax)
+
+
+def _resolve_cost_cmap(cmap):
+    return cost_field_cmap() if cmap is None else cmap
+
+
+def _label_cost_colorbar(cbar, vmin, *, normalize_range, log_scale):
+    if normalize_range and log_scale:
+        ticks = cbar.get_ticks()
+        cbar.set_ticks(ticks)
+        cbar.set_ticklabels([f"{t + vmin:.1f}" for t in ticks])
+
+
+def plot_cost_field(
+    grid: FieldGrid,
+    *,
+    ax=None,
+    cmap=None,
+    log_scale: bool = False,
+    vmax: float | None = None,
+    vmax_percentile: float = 99.0,
+    gamma: float = 0.55,
+    normalize_range: bool = True,
+    facecolor: str = "white",
+    colorbar: bool = True,
+    colorbar_label: str | None = None,
+    show: bool = True,
+    figsize=(6.0, 6.0),
+    title: str | None = "Spatial cost",
+    equal_aspect: bool = True,
+):
+    """Plot a workspace cost heatmap. Returns ``(fig, ax)``."""
+    import matplotlib.pyplot as plt
+
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figsize, frameon=True, facecolor=facecolor)
+    else:
+        fig = ax.figure
+
+    z, vmin, vmax, default_label = _cost_field_array(
+        grid,
+        log_scale=log_scale,
+        vmax=vmax,
+        vmax_percentile=vmax_percentile,
+        normalize_range=normalize_range,
+    )
+    cmap_resolved = _resolve_cost_cmap(cmap)
+    norm = _cost_field_norm(vmax, gamma=gamma)
+    ax.set_facecolor(facecolor)
+    image = ax.imshow(
+        z,
+        extent=grid.extent,
+        origin="lower",
+        cmap=cmap_resolved,
+        norm=norm,
+        aspect="auto",
+        zorder=1,
+    )
+    if colorbar:
+        label = colorbar_label if colorbar_label is not None else default_label
+        cbar = fig.colorbar(image, ax=ax, fraction=0.046, pad=0.04, label=label)
+        _label_cost_colorbar(
+            cbar, vmin, normalize_range=normalize_range, log_scale=log_scale
+        )
+    ax.set_xlim(grid.extent[0], grid.extent[1])
+    ax.set_ylim(grid.extent[2], grid.extent[3])
+    if equal_aspect:
+        ax.set_aspect("equal", adjustable="box")
+    ax.set_xlabel("x")
+    ax.set_ylabel("y")
+    ax.set_title(title)
+    ax.grid(True, alpha=0.25, zorder=0)
+
+    if show and plt.get_backend().lower() != "agg":
+        plt.show()
+
+    return fig, ax
+
+
+def plot_cost_field_3d(
+    grid: FieldGrid,
+    *,
+    ax=None,
+    cmap=None,
+    log_scale: bool = False,
+    vmax: float | None = None,
+    vmax_percentile: float = 99.0,
+    gamma: float = 0.55,
+    normalize_range: bool = True,
+    facecolor: str = "white",
+    colorbar: bool = True,
+    colorbar_label: str | None = None,
+    show: bool = True,
+    figsize=(8.0, 6.0),
+    title: str | None = "Spatial cost",
+    elev: float = 35.0,
+    azim: float = -60.0,
+    alpha: float = 0.92,
+    rstride: int = 1,
+    cstride: int = 1,
+):
+    """Plot workspace cost as a 3-D surface ``z = cost(x, y)``. Returns ``(fig, ax)``."""
+    import matplotlib.pyplot as plt
+
+    z, vmin, vmax, default_label = _cost_field_array(
+        grid,
+        log_scale=log_scale,
+        vmax=vmax,
+        vmax_percentile=vmax_percentile,
+        normalize_range=normalize_range,
+    )
+    cmap_resolved = _resolve_cost_cmap(cmap)
+    norm = _cost_field_norm(vmax, gamma=gamma)
+    x_grid, y_grid = np.meshgrid(grid.xs, grid.ys)
+
+    if ax is None:
+        fig = plt.figure(figsize=figsize, frameon=True, facecolor=facecolor)
+        ax = fig.add_subplot(111, projection="3d")
+    else:
+        fig = ax.figure
+
+    ax.set_facecolor(facecolor)
+    surface = ax.plot_surface(
+        x_grid,
+        y_grid,
+        z,
+        cmap=cmap_resolved,
+        norm=norm,
+        linewidth=0.0,
+        antialiased=True,
+        alpha=alpha,
+        rstride=rstride,
+        cstride=cstride,
+    )
+    if colorbar:
+        label = colorbar_label if colorbar_label is not None else default_label
+        cbar = fig.colorbar(surface, ax=ax, shrink=0.62, pad=0.08, label=label)
+        _label_cost_colorbar(
+            cbar, vmin, normalize_range=normalize_range, log_scale=log_scale
+        )
+    ax.set_xlabel("x")
+    ax.set_ylabel("y")
+    ax.set_zlabel(default_label)
+    ax.set_title(title)
+    ax.view_init(elev=elev, azim=azim)
+
+    if show and plt.get_backend().lower() != "agg":
+        plt.show()
+
+    return fig, ax
+
+
+def plot_cost_field_exports(
+    layers,
+    *,
+    track=None,
+    scene=None,
+    overlay_bounds=None,
+    traj=None,
+    log_scale: bool = True,
+    cmap=None,
+    save_dir=None,
+    show: bool = True,
+    figsize_2d=(9.0, 7.0),
+    figsize_3d=(9.0, 7.0),
+    surface_stride: int = 2,
+    **plot_kwargs,
+):
+    """
+    Plot each named cost layer in 2-D and 3-D with the same colormap.
+
+    Parameters
+    ----------
+    layers : dict[str, FieldGrid]
+        e.g. ``{"path": g, "corridor": g, "obstacle": g, "combined": g}``.
+    track, scene
+        Optional overlays drawn on the 2-D figures (``overlay_bounds`` for limits).
+    traj
+        Optional executed path ``(x, y)`` polyline on 2-D figures.
+    save_dir
+        If set, write ``{name}_2d.png`` and ``{name}_3d.png`` for each layer.
+    **plot_kwargs
+        Forwarded to :func:`plot_cost_field` / :func:`plot_cost_field_3d`
+        (``vmax_percentile``, ``gamma``, etc.).
+
+    Returns
+    -------
+    dict
+        ``{name: {"2d": (fig, ax), "3d": (fig, ax)}}``.
+    """
+    from pathlib import Path
+
+    import matplotlib.pyplot as plt
+
+    cmap_resolved = _resolve_cost_cmap(cmap)
+    shared = {"cmap": cmap_resolved, "log_scale": log_scale, **plot_kwargs}
+    out = {}
+    save_path = Path(save_dir) if save_dir is not None else None
+    if save_path is not None:
+        save_path.mkdir(parents=True, exist_ok=True)
+
+    for name, grid in layers.items():
+        title_2d = name.replace("_", " ").title()
+        title_2d_full = f"{title_2d} cost (2D)"
+        title_3d_full = f"{title_2d} cost (3D)"
+        fig2d, ax2d = plot_cost_field(
+            grid,
+            ax=None,
+            title=title_2d_full,
+            show=False,
+            figsize=figsize_2d,
+            **shared,
+        )
+        if track is not None:
+            track.plot(show=False, ax=ax2d, bounds=overlay_bounds, title="")
+        if scene is not None:
+            scene.plot(
+                show=False,
+                ax=ax2d,
+                bounds=overlay_bounds,
+                show_density=False,
+                title="",
+            )
+        if traj is not None:
+            ax2d.plot(
+                traj[0, :],
+                traj[1, :],
+                color="k",
+                linewidth=1.0,
+                alpha=0.85,
+                zorder=7,
+            )
+        ax2d.set_title(title_2d_full)
+        fig2d.tight_layout()
+
+        fig3d, ax3d = plot_cost_field_3d(
+            grid,
+            ax=None,
+            title=title_3d_full,
+            show=False,
+            figsize=figsize_3d,
+            rstride=surface_stride,
+            cstride=surface_stride,
+            **shared,
+        )
+        fig3d.tight_layout()
+
+        if save_path is not None:
+            fig2d.savefig(save_path / f"{name}_2d.png", dpi=160, bbox_inches="tight")
+            fig3d.savefig(save_path / f"{name}_3d.png", dpi=160, bbox_inches="tight")
+
+        out[name] = {"2d": (fig2d, ax2d), "3d": (fig3d, ax3d)}
+
+        if not show:
+            plt.close(fig2d)
+            plt.close(fig3d)
+
+    if show and plt.get_backend().lower() != "agg":
+        plt.show()
+
+    return out
 
 
 def _workspace_dim(scene) -> int:

--- a/tests/unittest/test_spatial.py
+++ b/tests/unittest/test_spatial.py
@@ -18,6 +18,7 @@ from minilink.planning.spatial.collision import (
     disc,
     point_probe,
 )
+from minilink.planning.spatial.grid import sample_field_costs
 from minilink.planning.spatial.scene import Scene
 from minilink.planning.spatial.shaping import (
     inverse_barrier,
@@ -378,3 +379,87 @@ def test_scene_plot_smoke():
 
     _, ax = scene.plot(show=False, body=_holonomic_point(), x=np.array([2.0, 0.0]))
     assert len(ax.lines) >= 1
+
+
+# --- workspace cost raster -------------------------------------------------
+
+
+def test_sample_field_costs_matches_point_probe_cost():
+    scene = Scene(obstacles=(Sphere([2.0, 0.0], 0.5),))
+    body = _holonomic_point()
+    cost = scene.clearance_field(body).as_cost(
+        weight=4.0, shaping=inverse_barrier(epsilon=0.1)
+    )
+    bounds = ((-1.0, 4.0), (-2.0, 2.0))
+    grid = sample_field_costs([cost], bounds=bounds, grid=(5, 4))
+    p = np.array([grid.xs[2], grid.ys[1]])
+    assert grid.Z[1, 2] == pytest.approx(cost.g(p, np.zeros(1)))
+
+
+def test_sample_field_costs_obstacle_is_radially_symmetric():
+    scene = Scene(obstacles=(Sphere([2.0, 0.0], 0.5),))
+    cost = scene.clearance_field(_holonomic_point()).as_cost(weight=1.0)
+    bounds = ((0.0, 4.0), (-2.0, 2.0))
+    grid = sample_field_costs([cost], bounds=bounds, grid=(41, 21))
+    center_j = int(np.argmin(np.abs(grid.ys)))
+    row = grid.Z[center_j, :]
+    xs = grid.xs
+    left = row[xs < 2.0]
+    right = row[xs > 2.0]
+    assert np.allclose(left, right[::-1], rtol=0.0, atol=1e-12)
+
+
+def test_cost_field_cmap_low_to_high_contrast():
+    from minilink.planning.spatial.plotting import cost_field_cmap
+
+    cmap = cost_field_cmap()
+    low = cmap(0.0)
+    high = cmap(1.0)
+    assert low[2] > low[0]  # blue end
+    assert high[0] > high[2]  # red end
+
+
+def test_plot_cost_field_exports_smoke(tmp_path):
+    import os
+
+    os.environ.setdefault("MPLBACKEND", "Agg")
+    import matplotlib
+
+    matplotlib.use("Agg", force=True)
+
+    from minilink.planning.spatial.plotting import plot_cost_field_exports
+
+    scene = Scene(obstacles=(Sphere([1.0, 0.0], 0.4),))
+    body = _holonomic_point()
+    bounds = ((-1.0, 3.0), (-1.0, 1.0))
+    path = scene.clearance_field(body).as_cost(weight=1.0)
+    corridor = scene.clearance_field(body).as_cost(weight=2.0)
+    obstacle = scene.clearance_field(body).as_cost(weight=3.0)
+    grids = {
+        "path": sample_field_costs([path], bounds=bounds, grid=(16, 14)),
+        "corridor": sample_field_costs([corridor], bounds=bounds, grid=(16, 14)),
+        "obstacle": sample_field_costs([obstacle], bounds=bounds, grid=(16, 14)),
+        "combined": sample_field_costs(
+            [path, corridor, obstacle], bounds=bounds, grid=(16, 14)
+        ),
+    }
+    out = plot_cost_field_exports(
+        grids,
+        scene=scene,
+        overlay_bounds=bounds,
+        log_scale=True,
+        show=False,
+        save_dir=tmp_path,
+    )
+    assert set(out) == {"path", "corridor", "obstacle", "combined"}
+    assert out["obstacle"]["2d"][1].get_title() == "Obstacle cost (2D)"
+    assert out["combined"]["3d"][1].get_title() == "Combined cost (3D)"
+    for entry in out.values():
+        fig2d, ax2d = entry["2d"]
+        fig3d, ax3d = entry["3d"]
+        assert fig2d is not None and ax2d is not None
+        assert fig3d is not None and ax3d is not None
+        assert len(fig2d.axes) == 2
+        assert len(fig3d.axes) == 2
+    assert (tmp_path / "combined_2d.png").exists()
+    assert (tmp_path / "combined_3d.png").exists()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pedagogical teaching tools for `planning/spatial` → MPC (rebased on `dev-mpc`).

1. **Script** — `demo_mpc_spatial_scene_guide.py` (spatial pipeline, no solve)
2. **Notebook** — `demo_mpc_spatial_scene_guide.ipynb` (manual NLP pipeline, planner wrapper, heatmaps, MPC)

Includes workspace cost field visualization (#53) on the same branch.

**Base branch:** `dev-mpc`

## Notebook highlights

- Two domains (workspace vs state), early map, probe vs body, hard vs soft exports
- Shaping curves, manual transcribe → MP → Optimizer → Trajectory
- Planner wrapper comparison, cost heatmaps, MPC closed loop
- Recap + optional exercises

## Run

```bash
python examples/scripts/mpc/demo_mpc_spatial_scene_guide.py
jupyter notebook examples/notebooks/demo_mpc_spatial_scene_guide.ipynb
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1e09-2b3a-78c3-8079-6d34cfe2c445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1e09-2b3a-78c3-8079-6d34cfe2c445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

